### PR TITLE
build: edc to 0.3.2-SNAPSHOT

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 format.version = "1.1"
 
 [versions]
-edc = "0.3.1"
+edc = "0.3.2-SNAPSHOT"
 
 [libraries]
 assertj = { module = "org.assertj:assertj-core", version = "3.24.2" }


### PR DESCRIPTION
### what
upgrades EDC version to 0.3.2-SNAPSHOT

### why
it will solve an issue on expanding the policy definition example.

It's needed for #6 