### PR TITLE
build: bump prism to 5.4.0

### DIFF
--- a/src/main/java/io/thinkit/edc/client/connector/EdcConnectorClient.java
+++ b/src/main/java/io/thinkit/edc/client/connector/EdcConnectorClient.java
@@ -29,7 +29,8 @@ public class EdcConnectorClient {
 
     public ContractDefinitions contractDefinitions() {
         if (managementUrl == null) {
-            throw new IllegalArgumentException("Cannot instantiate ContractDefinitions client without the management url");
+            throw new IllegalArgumentException(
+                    "Cannot instantiate ContractDefinitions client without the management url");
         }
         return new ContractDefinitions(managementUrl, httpClient, interceptor);
     }

--- a/src/test/java/io/thinkit/edc/client/connector/AssetsTest.java
+++ b/src/test/java/io/thinkit/edc/client/connector/AssetsTest.java
@@ -9,8 +9,6 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.BindMode;
-import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -18,15 +16,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 class AssetsTest {
 
     @Container
-    private GenericContainer<?> prism = new GenericContainer<>("stoplight/prism:3.3.4")
-            .withClasspathResourceMapping("/management-api.yml", "/management-api.yml", BindMode.READ_WRITE)
-            .withCommand("mock -h 0.0.0.0 -d /management-api.yml")
-            .withExposedPorts(4010)
-            .withLogConsumer(frame -> {
-                if (!frame.getUtf8String().contains("[CLI]")) {
-                    System.out.print(frame.getUtf8String());
-                }
-            });
+    private ManagementApiContainer prism = new ManagementApiContainer();
 
     private final HttpClient http = HttpClient.newBuilder().build();
     private Assets assets;

--- a/src/test/java/io/thinkit/edc/client/connector/ContractDefinitionsTest.java
+++ b/src/test/java/io/thinkit/edc/client/connector/ContractDefinitionsTest.java
@@ -5,8 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.net.http.HttpClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.BindMode;
-import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -14,15 +12,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 class ContractDefinitionsTest {
 
     @Container
-    private GenericContainer<?> prism = new GenericContainer<>("stoplight/prism:3.3.4")
-            .withClasspathResourceMapping("/management-api.yml", "/management-api.yml", BindMode.READ_WRITE)
-            .withCommand("mock -h 0.0.0.0 -d /management-api.yml")
-            .withExposedPorts(4010)
-            .withLogConsumer(frame -> {
-                if (!frame.getUtf8String().contains("[CLI]")) {
-                    System.out.print(frame.getUtf8String());
-                }
-            });
+    private ManagementApiContainer prism = new ManagementApiContainer();
 
     private final HttpClient http = HttpClient.newBuilder().build();
     private ContractDefinitions contractDefinitions;

--- a/src/test/java/io/thinkit/edc/client/connector/ManagementApiContainer.java
+++ b/src/test/java/io/thinkit/edc/client/connector/ManagementApiContainer.java
@@ -1,0 +1,20 @@
+package io.thinkit.edc.client.connector;
+
+import static org.testcontainers.containers.BindMode.READ_WRITE;
+
+import org.testcontainers.containers.GenericContainer;
+
+public class ManagementApiContainer extends GenericContainer<ManagementApiContainer> {
+
+    public ManagementApiContainer() {
+        super("stoplight/prism:5.4.0");
+        this.withClasspathResourceMapping("/management-api.yml", "/management-api.yml", READ_WRITE);
+        this.withCommand("mock -h 0.0.0.0 -d /management-api.yml");
+        this.withExposedPorts(4010);
+        this.withLogConsumer(frame -> {
+            if (!frame.getUtf8String().contains("[CLI]")) {
+                System.out.print(frame.getUtf8String());
+            }
+        });
+    }
+}


### PR DESCRIPTION
### what
Bump prism to 5.4.0

### why
dependency update

### how
extracted a separated class that wraps the prism testcontainer to avoid duplication