### PR TITLE
refactor: add asset builder

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,12 +50,14 @@ allprojects {
 
 val downloadOpenapiSpec by tasks.register("downloadOpenapiSpec") {
     dependsOn(tasks.findByName("processTestResources"))
+    val managementApi = sourceSets.test.get().output.resourcesDir?.let { File("$it/management-api.yml") }
+    onlyIf { managementApi?.exists()?.not() ?: false }
     doLast {
-        sourceSets.test.get().output.resourcesDir?.let { resourcesFolder ->
-            resourcesFolder.mkdirs()
+        managementApi?.let { fileSpec ->
+            fileSpec.parentFile.mkdirs()
             download("https://api.swaggerhub.com/apis/eclipse-edc-bot/management-api/${libs.versions.edc.get()}/yaml")
                 .replace("example: null", "")
-                .let { File("$resourcesFolder/management-api.yml").writeText(it) }
+                .let { fileSpec.writeText(it) }
         }
     }
 }

--- a/src/main/java/io/thinkit/edc/client/connector/Asset.java
+++ b/src/main/java/io/thinkit/edc/client/connector/Asset.java
@@ -3,10 +3,19 @@ package io.thinkit.edc.client.connector;
 import static io.thinkit.edc.client.connector.Constants.EDC_NAMESPACE;
 import static io.thinkit.edc.client.connector.Constants.ID;
 import static io.thinkit.edc.client.connector.Constants.VALUE;
+import static io.thinkit.edc.client.connector.Constants.VOCAB;
+import static jakarta.json.Json.createObjectBuilder;
 
 import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import java.util.Map;
 
 public class Asset {
+
+    private static final String ASSET_PROPERTIES = EDC_NAMESPACE + "properties";
+    private static final String ASSET_PRIVATE_PROPERTIES = EDC_NAMESPACE + "privateProperties";
+    private static final String ASSET_DATA_ADDRESS = EDC_NAMESPACE + "dataAddress";
+
     private final JsonObject raw;
 
     public Asset(JsonObject raw) {
@@ -18,16 +27,15 @@ public class Asset {
     }
 
     public Properties properties() {
-        return new Properties(raw.getJsonArray(EDC_NAMESPACE + "properties").getJsonObject(0));
+        return new Properties(raw.getJsonArray(ASSET_PROPERTIES).getJsonObject(0));
     }
 
     public Properties privateProperties() {
-        return new Properties(
-                raw.getJsonArray(EDC_NAMESPACE + "privateProperties").getJsonObject(0));
+        return new Properties(raw.getJsonArray(ASSET_PRIVATE_PROPERTIES).getJsonObject(0));
     }
 
     public DataAddress dataAddress() {
-        return new DataAddress(raw.getJsonArray(EDC_NAMESPACE + "dataAddress").getJsonObject(0));
+        return new DataAddress(raw.getJsonArray(ASSET_DATA_ADDRESS).getJsonObject(0));
     }
 
     public long createdAt() {
@@ -35,5 +43,49 @@ public class Asset {
                 .getJsonObject(0)
                 .getJsonNumber(VALUE)
                 .longValue();
+    }
+
+    public JsonObject raw() {
+        return raw;
+    }
+
+    public static class Builder {
+
+        private final JsonObjectBuilder raw = createObjectBuilder()
+                .add(Constants.CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE));
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Asset build() {
+            return new Asset(raw.build());
+        }
+
+        public Builder id(String id) {
+            raw.add(ID, id);
+            return this;
+        }
+
+        public Builder properties(Map<String, ?> properties) {
+            var builder = Properties.Builder.newInstance();
+            properties.forEach(builder::property);
+            raw.add(ASSET_PROPERTIES, builder.build().raw());
+            return this;
+        }
+
+        public Builder privateProperties(Map<String, ?> properties) {
+            var builder = Properties.Builder.newInstance();
+            properties.forEach(builder::property);
+            raw.add(ASSET_PRIVATE_PROPERTIES, builder.build().raw());
+            return this;
+        }
+
+        public Builder dataAddress(Map<String, ?> properties) {
+            var builder = Properties.Builder.newInstance();
+            properties.forEach(builder::property);
+            raw.add(ASSET_DATA_ADDRESS, builder.build().raw());
+            return this;
+        }
     }
 }

--- a/src/main/java/io/thinkit/edc/client/connector/Constants.java
+++ b/src/main/java/io/thinkit/edc/client/connector/Constants.java
@@ -8,4 +8,6 @@ public interface Constants {
     String ID = "@id";
     String TYPE = "@type";
     String VALUE = "@value";
+    String CONTEXT = "@context";
+    String VOCAB = "@vocab";
 }

--- a/src/main/java/io/thinkit/edc/client/connector/ContractDefinitions.java
+++ b/src/main/java/io/thinkit/edc/client/connector/ContractDefinitions.java
@@ -1,7 +1,10 @@
 package io.thinkit.edc.client.connector;
 
+import static io.thinkit.edc.client.connector.Constants.CONTEXT;
+import static io.thinkit.edc.client.connector.Constants.EDC_NAMESPACE;
 import static io.thinkit.edc.client.connector.Constants.ID;
 import static io.thinkit.edc.client.connector.Constants.TYPE;
+import static io.thinkit.edc.client.connector.Constants.VOCAB;
 
 import com.apicatalog.jsonld.JsonLd;
 import com.apicatalog.jsonld.JsonLdError;
@@ -58,6 +61,7 @@ public class ContractDefinitions {
     public Result<String> create(ContractDefinitionInput input) {
         try {
             Map<String, Object> requestBody = new HashMap<>();
+            requestBody.put(CONTEXT, Map.of(VOCAB, EDC_NAMESPACE));
             requestBody.put(ID, input.id());
             requestBody.put("accessPolicyId", input.accessPolicyId());
             requestBody.put("contractPolicyId", input.contractPolicyId());
@@ -157,6 +161,7 @@ public class ContractDefinitions {
     public Result<String> update(ContractDefinitionInput input) {
         try {
             Map<String, Object> requestBody = new HashMap<>();
+            requestBody.put(CONTEXT, Map.of(VOCAB, EDC_NAMESPACE));
             requestBody.put(ID, input.id());
             requestBody.put("accessPolicyId", input.accessPolicyId());
             requestBody.put("contractPolicyId", input.contractPolicyId());
@@ -174,9 +179,9 @@ public class ContractDefinitions {
             var response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
             var statusCode = response.statusCode();
             if (statusCode == 204) {
-                return new Result<>(true, input.id(), null);
+                return new Result<>(input.id(), null);
             } else {
-                return new Result<>(false, null, "Contract definition could not be updated");
+                return new Result<>(null, "Contract definition could not be updated");
             }
 
         } catch (IOException | InterruptedException e) {

--- a/src/main/java/io/thinkit/edc/client/connector/Properties.java
+++ b/src/main/java/io/thinkit/edc/client/connector/Properties.java
@@ -2,8 +2,14 @@ package io.thinkit.edc.client.connector;
 
 import static io.thinkit.edc.client.connector.Constants.EDC_NAMESPACE;
 import static io.thinkit.edc.client.connector.Constants.VALUE;
+import static jakarta.json.Json.createArrayBuilder;
+import static jakarta.json.Json.createObjectBuilder;
 
+import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonValue;
+import java.util.Map;
 import java.util.Optional;
 
 public class Properties {
@@ -25,5 +31,38 @@ public class Properties {
                 .map(it -> it.getJsonObject(0))
                 .map(it -> it.getString(VALUE))
                 .orElse(null);
+    }
+
+    public JsonValue raw() {
+        return raw;
+    }
+
+    public static class Builder {
+
+        private final JsonObjectBuilder raw = createObjectBuilder();
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Properties build() {
+            return new Properties(raw.build());
+        }
+
+        public Builder property(String key, Object value) {
+            JsonArray content;
+            if (value instanceof Map<?, ?> map) {
+                var builder = Builder.newInstance();
+                map.forEach((k, v) -> builder.property((String) k, v));
+                var properties = builder.build();
+                content = createArrayBuilder().add(properties.raw).build();
+            } else {
+                content = createArrayBuilder()
+                        .add(createObjectBuilder().add(VALUE, value.toString()))
+                        .build(); // TODO: watch out toString
+            }
+            raw.add(key, content);
+            return this;
+        }
     }
 }

--- a/src/test/java/io/thinkit/edc/client/connector/AssetsTest.java
+++ b/src/test/java/io/thinkit/edc/client/connector/AssetsTest.java
@@ -4,7 +4,6 @@ import static io.thinkit.edc.client.connector.Constants.EDC_NAMESPACE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.http.HttpClient;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,7 +24,6 @@ class AssetsTest {
     void setUp() {
         var client = EdcConnectorClient.newBuilder()
                 .httpClient(http)
-                .interceptor(r -> r.header("Prefer", "dynamic=false"))
                 .managementUrl("http://127.0.0.1:%s".formatted(prism.getFirstMappedPort()))
                 .build();
         assets = client.assets();
@@ -58,25 +56,34 @@ class AssetsTest {
 
     @Test
     void should_create_an_asset() {
-        Map<String, Object> properties = Map.of("key", Map.of("value", "value"));
-        Map<String, Object> privateProperties = Map.of("private-key", Map.of("private-value", "private-value"));
-        Map<String, Object> dataAddress = Map.of("type", "data-address-type");
-        var assetInput = new AssetInput("assetId", properties, privateProperties, dataAddress);
+        var properties = Map.of("key", Map.of("value", "value"));
+        var privateProperties = Map.of("private-key", Map.of("private-value", "private-value"));
+        var dataAddress = Map.of("type", "data-address-type");
 
-        Result<String> created = assets.create(assetInput);
+        var asset = Asset.Builder.newInstance()
+                .id("assetId")
+                .properties(properties)
+                .privateProperties(privateProperties)
+                .dataAddress(dataAddress)
+                .build();
+
+        var created = assets.create(asset);
 
         assertThat(created.isSucceeded()).isTrue();
         assertThat(created.getContent()).isNotNull();
     }
 
     @Test
-    void should_not_create_an_asset_when_dataAddress_is_empty() {
-        Map<String, Object> properties = Map.of("key", "value");
-        Map<String, Object> privateProperties = Map.of("private-key", "private-value");
-        Map<String, Object> dataAddress = Collections.emptyMap();
-        var assetInput = new AssetInput("assetId", properties, privateProperties, dataAddress);
+    void should_not_create_an_asset_when_data_address_is_missing() {
+        var properties = Map.of("key", "value");
+        var privateProperties = Map.of("private-key", "private-value");
+        var asset = Asset.Builder.newInstance()
+                .id("assetId")
+                .properties(properties)
+                .privateProperties(privateProperties)
+                .build();
 
-        Result<String> created = assets.create(assetInput);
+        var created = assets.create(asset);
 
         assertThat(created.isSucceeded()).isFalse();
         assertThat(created.getError()).isNotNull();
@@ -84,12 +91,17 @@ class AssetsTest {
 
     @Test
     void should_update_an_asset() {
-        Map<String, Object> properties = Map.of("key", Map.of("value", "value"));
-        Map<String, Object> privateProperties = Map.of("private-key", Map.of("private-value", "private-value"));
-        Map<String, Object> dataAddress = Map.of("type", "data-address-type");
-        var assetInput = new AssetInput("assetId", properties, privateProperties, dataAddress);
+        var properties = Map.of("key", Map.of("value", "value"));
+        var privateProperties = Map.of("private-key", Map.of("private-value", "private-value"));
+        var dataAddress = Map.of("type", "data-address-type");
+        var asset = Asset.Builder.newInstance()
+                .id("assetId")
+                .properties(properties)
+                .privateProperties(privateProperties)
+                .dataAddress(dataAddress)
+                .build();
 
-        Result<String> created = assets.update(assetInput);
+        var created = assets.update(asset);
 
         assertThat(created.isSucceeded()).isTrue();
     }
@@ -98,10 +110,13 @@ class AssetsTest {
     void should_not_update_an_asset_when_id_is_empty() {
         Map<String, Object> properties = Map.of("key", "value");
         Map<String, Object> privateProperties = Map.of("private-key", "private-value");
-        Map<String, Object> dataAddress = Collections.emptyMap();
-        var assetInput = new AssetInput("", properties, privateProperties, dataAddress);
+        var asset = Asset.Builder.newInstance()
+                .id("")
+                .properties(properties)
+                .privateProperties(privateProperties)
+                .build();
 
-        Result<String> created = assets.update(assetInput);
+        var created = assets.update(asset);
 
         assertThat(created.isSucceeded()).isFalse();
         assertThat(created.getError()).isNotNull();
@@ -110,14 +125,14 @@ class AssetsTest {
     @Test
     void should_delete_an_asset() {
 
-        Result<String> deleted = assets.delete("assetId");
+        var deleted = assets.delete("assetId");
 
         assertThat(deleted.isSucceeded()).isTrue();
     }
 
     @Test
     void should_not_delete_an_asset_when_id_is_empty() {
-        Result<String> deleted = assets.delete("");
+        var deleted = assets.delete("");
 
         assertThat(deleted.isSucceeded()).isFalse();
         assertThat(deleted.getError()).isNotNull();

--- a/src/test/java/io/thinkit/edc/client/connector/ContractDefinitionsTest.java
+++ b/src/test/java/io/thinkit/edc/client/connector/ContractDefinitionsTest.java
@@ -23,7 +23,6 @@ class ContractDefinitionsTest {
     void setUp() {
         var client = EdcConnectorClient.newBuilder()
                 .httpClient(http)
-                .interceptor(r -> r.header("Prefer", "dynamic=false"))
                 .managementUrl("http://127.0.0.1:%s".formatted(prism.getFirstMappedPort()))
                 .build();
         contractDefinitions = client.contractDefinitions();

--- a/src/test/java/io/thinkit/edc/client/connector/ManagementApiContainer.java
+++ b/src/test/java/io/thinkit/edc/client/connector/ManagementApiContainer.java
@@ -9,7 +9,7 @@ public class ManagementApiContainer extends GenericContainer<ManagementApiContai
     public ManagementApiContainer() {
         super("stoplight/prism:5.4.0");
         this.withClasspathResourceMapping("/management-api.yml", "/management-api.yml", READ_WRITE);
-        this.withCommand("mock -h 0.0.0.0 -d /management-api.yml");
+        this.withCommand("mock -h 0.0.0.0 /management-api.yml");
         this.withExposedPorts(4010);
         this.withLogConsumer(frame -> {
             if (!frame.getUtf8String().contains("[CLI]")) {

--- a/src/test/java/io/thinkit/edc/client/connector/PolicyDefinitionsTest.java
+++ b/src/test/java/io/thinkit/edc/client/connector/PolicyDefinitionsTest.java
@@ -21,7 +21,6 @@ public class PolicyDefinitionsTest {
     void setUp() {
         var client = EdcConnectorClient.newBuilder()
                 .httpClient(http)
-                .interceptor(r -> r.header("Prefer", "dynamic=false"))
                 .managementUrl("http://127.0.0.1:%s".formatted(prism.getFirstMappedPort()))
                 .build();
         policyDefinitions = client.policyDefinitions();


### PR DESCRIPTION
### What
Adds a `Asset.Builder` that can replace the `AssetInput` and the necessity to pass through a `Map` to create a new asset.

### Why
Simplify

### How
The builder methods will ensure that the `raw` object is always an expanded expression of the asset, then the object will be compacted right before the request. If this is the way we want to follow we can use this way also for contract definitions and policy definitions.

### Further notes
- I also changed the `downloadOpenapiSpec` to download the spec only if the file is not existing, so for download a new version, a `./gradlew clean` must be done before.
- I noticed that we were starting the prism mock server with the `-d` (dynamic) flag and then disabling the dynamic with a specific header, removing that `-d` flag, the header was not needed anymore