### PR TITLE
refactor: avoid passing thorugh to a map when requesting assets

### DIFF
--- a/src/main/java/io/thinkit/edc/client/connector/Asset.java
+++ b/src/main/java/io/thinkit/edc/client/connector/Asset.java
@@ -1,90 +1,87 @@
 package io.thinkit.edc.client.connector;
 
+import static io.thinkit.edc.client.connector.Constants.CONTEXT;
 import static io.thinkit.edc.client.connector.Constants.EDC_NAMESPACE;
 import static io.thinkit.edc.client.connector.Constants.ID;
-import static io.thinkit.edc.client.connector.Constants.VALUE;
+import static io.thinkit.edc.client.connector.Constants.TYPE;
 import static io.thinkit.edc.client.connector.Constants.VOCAB;
 import static jakarta.json.Json.createObjectBuilder;
 
+import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 import java.util.Map;
 
-public class Asset {
+public class Asset extends JsonLdObject {
 
+    private static final String TYPE_ASSET = EDC_NAMESPACE + "Asset";
     private static final String ASSET_PROPERTIES = EDC_NAMESPACE + "properties";
     private static final String ASSET_PRIVATE_PROPERTIES = EDC_NAMESPACE + "privateProperties";
     private static final String ASSET_DATA_ADDRESS = EDC_NAMESPACE + "dataAddress";
+    private static final String ASSET_CREATED_AT = EDC_NAMESPACE + "createdAt";
 
-    private final JsonObject raw;
-
-    public Asset(JsonObject raw) {
-        this.raw = raw;
-    }
-
-    public String id() {
-        return raw.getString(ID);
+    private Asset(JsonObject raw) {
+        super(raw);
     }
 
     public Properties properties() {
-        return new Properties(raw.getJsonArray(ASSET_PROPERTIES).getJsonObject(0));
+        return new Properties(object(ASSET_PROPERTIES));
     }
 
     public Properties privateProperties() {
-        return new Properties(raw.getJsonArray(ASSET_PRIVATE_PROPERTIES).getJsonObject(0));
+        return new Properties(object(ASSET_PRIVATE_PROPERTIES));
     }
 
     public DataAddress dataAddress() {
-        return new DataAddress(raw.getJsonArray(ASSET_DATA_ADDRESS).getJsonObject(0));
+        return new DataAddress(object(ASSET_DATA_ADDRESS));
     }
 
     public long createdAt() {
-        return raw.getJsonArray(EDC_NAMESPACE + "createdAt")
-                .getJsonObject(0)
-                .getJsonNumber(VALUE)
-                .longValue();
-    }
-
-    public JsonObject raw() {
-        return raw;
+        return longValue(ASSET_CREATED_AT);
     }
 
     public static class Builder {
 
-        private final JsonObjectBuilder raw = createObjectBuilder()
-                .add(Constants.CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE));
+        private final JsonObjectBuilder builder = createObjectBuilder()
+                .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
+                .add(TYPE, TYPE_ASSET);
 
         public static Builder newInstance() {
             return new Builder();
         }
 
         public Asset build() {
-            return new Asset(raw.build());
+            return new Asset(builder.build());
         }
 
         public Builder id(String id) {
-            raw.add(ID, id);
+            builder.add(ID, id);
             return this;
         }
 
         public Builder properties(Map<String, ?> properties) {
-            var builder = Properties.Builder.newInstance();
-            properties.forEach(builder::property);
-            raw.add(ASSET_PROPERTIES, builder.build().raw());
+            var propertiesBuilder = Properties.Builder.newInstance();
+            properties.forEach(propertiesBuilder::property);
+            builder.add(ASSET_PROPERTIES, propertiesBuilder.build().raw());
             return this;
         }
 
         public Builder privateProperties(Map<String, ?> properties) {
-            var builder = Properties.Builder.newInstance();
-            properties.forEach(builder::property);
-            raw.add(ASSET_PRIVATE_PROPERTIES, builder.build().raw());
+            var propertiesBuilder = Properties.Builder.newInstance();
+            properties.forEach(propertiesBuilder::property);
+            builder.add(ASSET_PRIVATE_PROPERTIES, propertiesBuilder.build().raw());
             return this;
         }
 
         public Builder dataAddress(Map<String, ?> properties) {
-            var builder = Properties.Builder.newInstance();
-            properties.forEach(builder::property);
-            raw.add(ASSET_DATA_ADDRESS, builder.build().raw());
+            var propertiesBuilder = Properties.Builder.newInstance();
+            properties.forEach(propertiesBuilder::property);
+            builder.add(ASSET_DATA_ADDRESS, propertiesBuilder.build().raw());
+            return this;
+        }
+
+        public Builder raw(JsonObject raw) {
+            builder.addAll(Json.createObjectBuilder(raw));
             return this;
         }
     }

--- a/src/main/java/io/thinkit/edc/client/connector/ContractDefinition.java
+++ b/src/main/java/io/thinkit/edc/client/connector/ContractDefinition.java
@@ -31,7 +31,7 @@ public class ContractDefinition {
 
     public List<Criterion> assetsSelector() {
         return raw.getJsonArray(EDC_NAMESPACE + "assetsSelector").stream()
-                .map(s -> new Criterion(s.asJsonObject()))
+                .map(s -> Criterion.Builder.newInstance().raw(s.asJsonObject()).build())
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/io/thinkit/edc/client/connector/ContractDefinitions.java
+++ b/src/main/java/io/thinkit/edc/client/connector/ContractDefinitions.java
@@ -3,8 +3,9 @@ package io.thinkit.edc.client.connector;
 import static io.thinkit.edc.client.connector.Constants.CONTEXT;
 import static io.thinkit.edc.client.connector.Constants.EDC_NAMESPACE;
 import static io.thinkit.edc.client.connector.Constants.ID;
-import static io.thinkit.edc.client.connector.Constants.TYPE;
 import static io.thinkit.edc.client.connector.Constants.VOCAB;
+import static io.thinkit.edc.client.connector.JsonLdUtil.compact;
+import static java.net.http.HttpRequest.BodyPublishers.ofString;
 
 import com.apicatalog.jsonld.JsonLd;
 import com.apicatalog.jsonld.JsonLdError;
@@ -41,14 +42,14 @@ public class ContractDefinitions {
 
             var response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
             var statusCode = response.statusCode();
-            boolean succeeded = statusCode == 200;
+            var succeeded = statusCode == 200;
             if (succeeded) {
                 var jsonDocument = JsonDocument.of(response.body());
                 var jsonArray = JsonLd.expand(jsonDocument).get();
-                ContractDefinition contractDefinition = new ContractDefinition(jsonArray.getJsonObject(0));
+                var contractDefinition = new ContractDefinition(jsonArray.getJsonObject(0));
                 return new Result<>(contractDefinition, null);
             } else {
-                String error = (statusCode == 400)
+                var error = (statusCode == 400)
                         ? "Request body was malformed"
                         : "A contract definition with the given ID does not exist";
                 return new Result<>(error);
@@ -72,21 +73,20 @@ public class ContractDefinitions {
             var requestBuilder = HttpRequest.newBuilder()
                     .uri(URI.create("%s/v2/contractdefinitions".formatted(url)))
                     .header("content-type", "application/json")
-                    .POST(HttpRequest.BodyPublishers.ofString(jsonRequestBody));
+                    .POST(ofString(jsonRequestBody));
 
             var request = interceptor.apply(requestBuilder).build();
 
             var response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
             var statusCode = response.statusCode();
-            boolean succeeded = statusCode == 200;
+            var succeeded = statusCode == 200;
             if (succeeded) {
                 var jsonDocument = JsonDocument.of(response.body());
                 var jsonArray = JsonLd.expand(jsonDocument).get();
-                String id = jsonArray.getJsonObject(0).getString(ID);
+                var id = jsonArray.getJsonObject(0).getString(ID);
                 return new Result<>(id, null);
             } else {
-                String error =
-                        (statusCode == 400) ? "Request body was malformed" : "Could not create contract definition";
+                var error = (statusCode == 400) ? "Request body was malformed" : "Could not create contract definition";
                 return new Result<>(null, error);
             }
 
@@ -117,26 +117,12 @@ public class ContractDefinitions {
 
     public Result<List<ContractDefinition>> request(QuerySpec input) {
         try {
-            Map<String, Object> requestBody = Map.of(
-                    TYPE,
-                    "https://w3id.org/edc/v0.0.1/ns/QuerySpec",
-                    "offset",
-                    input.offset(),
-                    "limit",
-                    input.limit(),
-                    "sortOrder",
-                    input.sortOrder(),
-                    "sortField",
-                    input.sortField(),
-                    "filterExpression",
-                    input.filterExpression());
-
-            var jsonRequestBody = new ObjectMapper().writeValueAsString(requestBody);
+            var requestBody = compact(input);
 
             var requestBuilder = HttpRequest.newBuilder()
                     .uri(URI.create("%s/v2/contractdefinitions/request".formatted(url)))
                     .header("content-type", "application/json")
-                    .POST(HttpRequest.BodyPublishers.ofString(jsonRequestBody));
+                    .POST(ofString(requestBody.toString()));
 
             var request = interceptor.apply(requestBuilder).build();
 
@@ -145,7 +131,7 @@ public class ContractDefinitions {
             if (statusCode == 200) {
                 var jsonDocument = JsonDocument.of(response.body());
                 var jsonArray = JsonLd.expand(jsonDocument).get();
-                List<ContractDefinition> contractDefinitions = jsonArray.stream()
+                var contractDefinitions = jsonArray.stream()
                         .map(s -> new ContractDefinition(s.asJsonObject()))
                         .toList();
                 return new Result<>(contractDefinitions, null);
@@ -172,7 +158,7 @@ public class ContractDefinitions {
             var requestBuilder = HttpRequest.newBuilder()
                     .uri(URI.create("%s/v2/contractdefinitions".formatted(url)))
                     .header("content-type", "application/json")
-                    .PUT(HttpRequest.BodyPublishers.ofString(jsonRequestBody));
+                    .PUT(ofString(jsonRequestBody));
 
             var request = interceptor.apply(requestBuilder).build();
 

--- a/src/main/java/io/thinkit/edc/client/connector/Criterion.java
+++ b/src/main/java/io/thinkit/edc/client/connector/Criterion.java
@@ -1,25 +1,52 @@
 package io.thinkit.edc.client.connector;
 
-import static io.thinkit.edc.client.connector.Constants.*;
+import static io.thinkit.edc.client.connector.Constants.CONTEXT;
+import static io.thinkit.edc.client.connector.Constants.EDC_NAMESPACE;
+import static io.thinkit.edc.client.connector.Constants.TYPE;
+import static io.thinkit.edc.client.connector.Constants.VOCAB;
+import static jakarta.json.Json.createObjectBuilder;
 
 import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
 
-public class Criterion {
-    private final JsonObject raw;
+public class Criterion extends JsonLdObject {
 
-    public Criterion(JsonObject raw) {
-        this.raw = raw;
+    private static final String CRITERION_OPERATOR = EDC_NAMESPACE + "operator";
+    private static final String CRITERION_OPERAND_LEFT = EDC_NAMESPACE + "operandLeft";
+    private static final String CRITERION_OPERAND_RIGHT = EDC_NAMESPACE + "operandRight";
+
+    private Criterion(JsonObject raw) {
+        super(raw);
     }
 
     public String operator() {
-        return raw.getJsonArray(EDC_NAMESPACE + "operator").getJsonObject(0).getString(VALUE);
+        return stringValue(CRITERION_OPERATOR);
     }
 
     public Object operandLeft() {
-        return raw.getJsonArray(EDC_NAMESPACE + "operandLeft").getJsonObject(0);
+        return stringValue(CRITERION_OPERAND_LEFT);
     }
 
     public Object operandRight() {
-        return raw.getJsonArray(EDC_NAMESPACE + "operandRight").getJsonObject(0);
+        return stringValue(CRITERION_OPERAND_RIGHT);
+    }
+
+    public static class Builder {
+        private final JsonObjectBuilder raw = createObjectBuilder()
+                .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
+                .add(TYPE, EDC_NAMESPACE + "Criterion");
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Criterion build() {
+            return new Criterion(raw.build());
+        }
+
+        public Builder raw(JsonObject raw) {
+            this.raw.addAll(createObjectBuilder(raw));
+            return this;
+        }
     }
 }

--- a/src/main/java/io/thinkit/edc/client/connector/JsonLdObject.java
+++ b/src/main/java/io/thinkit/edc/client/connector/JsonLdObject.java
@@ -1,0 +1,45 @@
+package io.thinkit.edc.client.connector;
+
+import static io.thinkit.edc.client.connector.Constants.ID;
+import static io.thinkit.edc.client.connector.Constants.VALUE;
+
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import java.util.stream.Stream;
+
+public class JsonLdObject {
+
+    private final JsonObject raw;
+
+    public JsonLdObject(JsonObject raw) {
+        this.raw = raw;
+    }
+
+    public JsonObject raw() {
+        return raw;
+    }
+
+    public String id() {
+        return raw.getString(ID);
+    }
+
+    protected JsonObject object(String key) {
+        return raw.getJsonArray(key).getJsonObject(0);
+    }
+
+    protected Stream<JsonObject> objects(String key) {
+        return raw.getJsonArray(key).stream().map(JsonValue::asJsonObject);
+    }
+
+    protected String stringValue(String key) {
+        return raw.getJsonArray(key).getJsonObject(0).getString(VALUE);
+    }
+
+    protected long longValue(String key) {
+        return raw.getJsonArray(key).getJsonObject(0).getJsonNumber(VALUE).longValue();
+    }
+
+    protected int intValue(String key) {
+        return raw.getJsonArray(key).getJsonObject(0).getJsonNumber(VALUE).intValue();
+    }
+}

--- a/src/main/java/io/thinkit/edc/client/connector/JsonLdUtil.java
+++ b/src/main/java/io/thinkit/edc/client/connector/JsonLdUtil.java
@@ -1,0 +1,29 @@
+package io.thinkit.edc.client.connector;
+
+import static io.thinkit.edc.client.connector.Constants.CONTEXT;
+import static io.thinkit.edc.client.connector.Constants.EDC_NAMESPACE;
+import static io.thinkit.edc.client.connector.Constants.VOCAB;
+
+import com.apicatalog.jsonld.JsonLd;
+import com.apicatalog.jsonld.JsonLdError;
+import com.apicatalog.jsonld.document.JsonDocument;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import java.io.InputStream;
+
+public class JsonLdUtil {
+
+    public static JsonArray expand(InputStream body) throws JsonLdError {
+        var jsonDocument = JsonDocument.of(body);
+        return JsonLd.expand(jsonDocument).get();
+    }
+
+    public static JsonObject compact(JsonLdObject input) throws JsonLdError {
+        var expanded = JsonDocument.of(input.raw());
+        var context = JsonDocument.of(Json.createObjectBuilder()
+                .add(CONTEXT, Json.createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
+                .build());
+        return JsonLd.compact(expanded, context).get();
+    }
+}

--- a/src/main/java/io/thinkit/edc/client/connector/QuerySpec.java
+++ b/src/main/java/io/thinkit/edc/client/connector/QuerySpec.java
@@ -1,3 +1,92 @@
 package io.thinkit.edc.client.connector;
 
-public record QuerySpec(int offset, int limit, String sortOrder, String sortField, CriterionInput[] filterExpression) {}
+import static io.thinkit.edc.client.connector.Constants.CONTEXT;
+import static io.thinkit.edc.client.connector.Constants.EDC_NAMESPACE;
+import static io.thinkit.edc.client.connector.Constants.TYPE;
+import static io.thinkit.edc.client.connector.Constants.VALUE;
+import static io.thinkit.edc.client.connector.Constants.VOCAB;
+import static jakarta.json.Json.createArrayBuilder;
+import static jakarta.json.Json.createObjectBuilder;
+import static jakarta.json.stream.JsonCollectors.toJsonArray;
+
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import java.util.List;
+
+public class QuerySpec extends JsonLdObject {
+
+    private static final String TYPE_QUERY_SPEC = EDC_NAMESPACE + "QuerySpec";
+    private static final String QUERY_SPEC_OFFSET = EDC_NAMESPACE + "offset";
+    private static final String QUERY_SPEC_LIMIT = EDC_NAMESPACE + "limit";
+    private static final String QUERY_SPEC_SORT_ORDER = EDC_NAMESPACE + "sortOrder";
+    private static final String QUERY_SPEC_SORT_FIELD = EDC_NAMESPACE + "sortField";
+    private static final String QUERY_SPEC_FILTER_EXPRESSION = EDC_NAMESPACE + "filterExpression";
+
+    private QuerySpec(JsonObject raw) {
+        super(raw);
+    }
+
+    public int offset() {
+        return intValue(QUERY_SPEC_OFFSET);
+    }
+
+    public int limit() {
+        return intValue(QUERY_SPEC_LIMIT);
+    }
+
+    public String sortOrder() {
+        return stringValue(QUERY_SPEC_SORT_ORDER);
+    }
+
+    public String sortField() {
+        return stringValue(QUERY_SPEC_SORT_FIELD);
+    }
+
+    public List<Criterion> filterExpression() {
+        return objects(QUERY_SPEC_FILTER_EXPRESSION)
+                .map(it -> Criterion.Builder.newInstance().raw(it).build())
+                .toList();
+    }
+
+    public static final class Builder {
+
+        private final JsonObjectBuilder raw = createObjectBuilder()
+                .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
+                .add(TYPE, TYPE_QUERY_SPEC);
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public QuerySpec build() {
+            return new QuerySpec(raw.build());
+        }
+
+        public Builder offset(int offset) {
+            raw.add(
+                    QUERY_SPEC_OFFSET,
+                    createArrayBuilder().add(createObjectBuilder().add(VALUE, offset)));
+            return this;
+        }
+
+        public Builder limit(int limit) {
+            raw.add("limit", createArrayBuilder().add(createObjectBuilder().add(VALUE, limit)));
+            return this;
+        }
+
+        public Builder sortOrder(String sortOrder) {
+            raw.add("sortOrder", createArrayBuilder().add(createObjectBuilder().add(VALUE, sortOrder)));
+            return this;
+        }
+
+        public Builder sortField(String sortField) {
+            raw.add("sortField", createArrayBuilder().add(createObjectBuilder().add(VALUE, sortField)));
+            return this;
+        }
+
+        public Builder filterExpression(List<Criterion> criteria) {
+            raw.add("filterExpression", criteria.stream().map(Criterion::raw).collect(toJsonArray()));
+            return this;
+        }
+    }
+}

--- a/src/test/java/io/thinkit/edc/client/connector/AssetsTest.java
+++ b/src/test/java/io/thinkit/edc/client/connector/AssetsTest.java
@@ -1,10 +1,10 @@
 package io.thinkit.edc.client.connector;
 
 import static io.thinkit.edc.client.connector.Constants.EDC_NAMESPACE;
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.http.HttpClient;
-import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,7 +31,7 @@ class AssetsTest {
 
     @Test
     void should_get_an_asset() {
-        Result<Asset> asset = assets.get("123");
+        var asset = assets.get("123");
 
         assertThat(asset.getContent().id()).isNotBlank();
         assertThat(asset.getContent().properties()).isNotNull().satisfies(properties -> {
@@ -124,7 +124,6 @@ class AssetsTest {
 
     @Test
     void should_delete_an_asset() {
-
         var deleted = assets.delete("assetId");
 
         assertThat(deleted.isSucceeded()).isTrue();
@@ -140,8 +139,16 @@ class AssetsTest {
 
     @Test
     void should_get_assets() {
-        var input = new QuerySpec(5, 10, "DESC", "fieldName", new CriterionInput[] {});
-        Result<List<Asset>> assetsList = assets.request(input);
+        var query = QuerySpec.Builder.newInstance()
+                .offset(5)
+                .limit(10)
+                .sortOrder("DESC")
+                .sortField("fieldName")
+                .filterExpression(emptyList())
+                .build();
+
+        var assetsList = assets.request(query);
+
         assertThat(assetsList.isSucceeded()).isTrue();
         assertThat(assetsList.getContent()).isNotNull().first().satisfies(asset -> {
             assertThat(asset.id()).isNotBlank();
@@ -167,9 +174,10 @@ class AssetsTest {
     }
 
     @Test
-    void should_not_get_assets() {
-        var input = new QuerySpec(0, 0, "", "", new CriterionInput[] {});
-        Result<List<Asset>> assetsList = assets.request(input);
+    void should_not_get_assets_when_sort_schema_is_not_as_expected() {
+        var input = QuerySpec.Builder.newInstance().sortOrder("wrong").build();
+
+        var assetsList = assets.request(input);
 
         assertThat(assetsList.isSucceeded()).isFalse();
         assertThat(assetsList.getError()).isNotNull();

--- a/src/test/java/io/thinkit/edc/client/connector/ContractDefinitionsTest.java
+++ b/src/test/java/io/thinkit/edc/client/connector/ContractDefinitionsTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.http.HttpClient;
 import java.util.ArrayList;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
@@ -30,7 +29,7 @@ class ContractDefinitionsTest {
 
     @Test
     void should_get_a_contract_definition() {
-        Result<ContractDefinition> contractDefinition = contractDefinitions.get("definition-id");
+        var contractDefinition = contractDefinitions.get("definition-id");
 
         assertThat(contractDefinition.isSucceeded()).isTrue();
         assertThat(contractDefinition.getContent().id()).isNotBlank();
@@ -45,7 +44,7 @@ class ContractDefinitionsTest {
 
     @Test
     void should_not_get_a_contract_definition_when_id_is_empty() {
-        Result<ContractDefinition> contractDefinition = contractDefinitions.get("");
+        var contractDefinition = contractDefinitions.get("");
 
         assertThat(contractDefinition.isSucceeded()).isFalse();
         assertThat(contractDefinition.getError()).isNotNull();
@@ -56,7 +55,7 @@ class ContractDefinitionsTest {
         var contractDefinitionInput = new ContractDefinitionInput(
                 "definition-id", "asset-policy-id", "contract-policy-id", new ArrayList<>());
 
-        Result<String> created = contractDefinitions.create(contractDefinitionInput);
+        var created = contractDefinitions.create(contractDefinitionInput);
 
         assertThat(created.isSucceeded()).isTrue();
         assertThat(created.getContent()).isNotNull();
@@ -67,7 +66,7 @@ class ContractDefinitionsTest {
         var contractDefinitionInput =
                 new ContractDefinitionInput("definition-id", null, "contract-policy-id", new ArrayList<>());
 
-        Result<String> created = contractDefinitions.create(contractDefinitionInput);
+        var created = contractDefinitions.create(contractDefinitionInput);
 
         assertThat(created.isSucceeded()).isFalse();
         assertThat(created.getError()).isNotNull();
@@ -76,15 +75,14 @@ class ContractDefinitionsTest {
     @Test
     void should_delete_a_contract_definition() {
 
-        Result<String> deleted = contractDefinitions.delete("definition-id");
+        var deleted = contractDefinitions.delete("definition-id");
 
         assertThat(deleted.isSucceeded()).isTrue();
     }
 
     @Test
     void should_not_delete_a_contract_definition_when_id_is_empty() {
-
-        Result<String> deleted = contractDefinitions.delete("");
+        var deleted = contractDefinitions.delete("");
 
         assertThat(deleted.isSucceeded()).isFalse();
         assertThat(deleted.getError()).isNotNull();
@@ -92,8 +90,15 @@ class ContractDefinitionsTest {
 
     @Test
     void should_get_contract_definitions() {
-        var input = new QuerySpec(5, 10, "DESC", "fieldName", new CriterionInput[] {});
-        Result<List<ContractDefinition>> ContractDefinitionList = contractDefinitions.request(input);
+        var input = QuerySpec.Builder.newInstance()
+                .offset(0)
+                .limit(10)
+                .sortOrder("DESC")
+                .sortField("fieldName")
+                .build();
+
+        var ContractDefinitionList = contractDefinitions.request(input);
+
         assertThat(ContractDefinitionList.isSucceeded()).isTrue();
         assertThat(ContractDefinitionList.getContent()).isNotNull().first().satisfies(contractDefinition -> {
             assertThat(contractDefinition.id()).isNotBlank();
@@ -109,19 +114,20 @@ class ContractDefinitionsTest {
 
     @Test
     void should_not_get_contract_definitions() {
-        var input = new QuerySpec(0, 0, "", "", new CriterionInput[] {});
-        Result<List<ContractDefinition>> ContractDefinitionList = contractDefinitions.request(input);
+        var input = QuerySpec.Builder.newInstance().sortOrder("wrong").build();
 
-        assertThat(ContractDefinitionList.isSucceeded()).isFalse();
-        assertThat(ContractDefinitionList.getError()).isNotNull();
+        var result = contractDefinitions.request(input);
+
+        assertThat(result.isSucceeded()).isFalse();
+        assertThat(result.getError()).isNotNull();
     }
 
     @Test
     void should_update_a_contract_definition() {
         var contractDefinitionInput = new ContractDefinitionInput(
-                "definition-id", "asset-policy-id", "contract-policy-id", new ArrayList<CriterionInput>());
+                "definition-id", "asset-policy-id", "contract-policy-id", new ArrayList<>());
 
-        Result<String> created = contractDefinitions.update(contractDefinitionInput);
+        var created = contractDefinitions.update(contractDefinitionInput);
 
         assertThat(created.isSucceeded()).isTrue();
         assertThat(created.getContent()).isNotNull();
@@ -129,10 +135,10 @@ class ContractDefinitionsTest {
 
     @Test
     void should_not_update_a_contract_definition_when_id_is_empty() {
-        var contractDefinitionInput = new ContractDefinitionInput(
-                null, "asset-policy-id", "contract-policy-id", new ArrayList<CriterionInput>());
+        var contractDefinitionInput =
+                new ContractDefinitionInput(null, "asset-policy-id", "contract-policy-id", new ArrayList<>());
 
-        Result<String> created = contractDefinitions.update(contractDefinitionInput);
+        var created = contractDefinitions.update(contractDefinitionInput);
 
         assertThat(created.isSucceeded()).isFalse();
         assertThat(created.getError()).isNotNull();


### PR DESCRIPTION
### What
continuing the work to uniform input and output object. Now also `QuerySpec` can be built with a builder

### Why
uniform codebase

### How
I added a `JsonLdObject` abstraction, that permits to generify the `raw` field, that will be present in every model class.
There is still work to be done, I would postpone it to subsequent PRs