### PR TITLE
refactor: add an abstract builder in the JsonLdObject class

### DIFF
--- a/src/main/java/io/thinkit/edc/client/connector/Asset.java
+++ b/src/main/java/io/thinkit/edc/client/connector/Asset.java
@@ -1,15 +1,9 @@
 package io.thinkit.edc.client.connector;
 
-import static io.thinkit.edc.client.connector.Constants.CONTEXT;
 import static io.thinkit.edc.client.connector.Constants.EDC_NAMESPACE;
-import static io.thinkit.edc.client.connector.Constants.ID;
 import static io.thinkit.edc.client.connector.Constants.TYPE;
-import static io.thinkit.edc.client.connector.Constants.VOCAB;
-import static jakarta.json.Json.createObjectBuilder;
 
-import jakarta.json.Json;
 import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
 import java.util.Map;
 
 public class Asset extends JsonLdObject {
@@ -40,23 +34,14 @@ public class Asset extends JsonLdObject {
         return longValue(ASSET_CREATED_AT);
     }
 
-    public static class Builder {
-
-        private final JsonObjectBuilder builder = createObjectBuilder()
-                .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
-                .add(TYPE, TYPE_ASSET);
+    public static class Builder extends AbstractBuilder<Asset, Builder> {
 
         public static Builder newInstance() {
             return new Builder();
         }
 
         public Asset build() {
-            return new Asset(builder.build());
-        }
-
-        public Builder id(String id) {
-            builder.add(ID, id);
-            return this;
+            return new Asset(builder.add(TYPE, TYPE_ASSET).build());
         }
 
         public Builder properties(Map<String, ?> properties) {
@@ -77,11 +62,6 @@ public class Asset extends JsonLdObject {
             var propertiesBuilder = Properties.Builder.newInstance();
             properties.forEach(propertiesBuilder::property);
             builder.add(ASSET_DATA_ADDRESS, propertiesBuilder.build().raw());
-            return this;
-        }
-
-        public Builder raw(JsonObject raw) {
-            builder.addAll(Json.createObjectBuilder(raw));
             return this;
         }
     }

--- a/src/main/java/io/thinkit/edc/client/connector/CallbackAddress.java
+++ b/src/main/java/io/thinkit/edc/client/connector/CallbackAddress.java
@@ -6,7 +6,6 @@ import static jakarta.json.Json.createObjectBuilder;
 
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
 import java.util.List;
 
 public class CallbackAddress extends JsonLdObject {
@@ -41,18 +40,14 @@ public class CallbackAddress extends JsonLdObject {
         return objects(CALLBACK_ADDRESS_EVENTS).map(it -> it.getString(VALUE)).toList();
     }
 
-    public static class Builder {
-
-        private final JsonObjectBuilder builder = createObjectBuilder()
-                .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
-                .add(TYPE, TYPE_CALLBACK_ADDRESS);
+    public static class Builder extends AbstractBuilder<CallbackAddress, Builder> {
 
         public static CallbackAddress.Builder newInstance() {
             return new CallbackAddress.Builder();
         }
 
         public CallbackAddress build() {
-            return new CallbackAddress(builder.build());
+            return new CallbackAddress(builder.add(TYPE, TYPE_CALLBACK_ADDRESS).build());
         }
 
         public CallbackAddress.Builder authCodeId(String authCodeId) {
@@ -85,11 +80,6 @@ public class CallbackAddress extends JsonLdObject {
 
         public CallbackAddress.Builder events(List<String> events) {
             builder.add(CALLBACK_ADDRESS_EVENTS, Json.createArrayBuilder(events));
-            return this;
-        }
-
-        public CallbackAddress.Builder raw(JsonObject raw) {
-            builder.addAll(Json.createObjectBuilder(raw));
             return this;
         }
     }

--- a/src/main/java/io/thinkit/edc/client/connector/CatalogRequest.java
+++ b/src/main/java/io/thinkit/edc/client/connector/CatalogRequest.java
@@ -6,7 +6,6 @@ import static jakarta.json.Json.createObjectBuilder;
 
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
 
 public class CatalogRequest extends JsonLdObject {
     private static final String TYPE_CATALOG_REQUEST = EDC_NAMESPACE + "CatalogRequest";
@@ -32,18 +31,14 @@ public class CatalogRequest extends JsonLdObject {
                 .build();
     }
 
-    public static class Builder {
-
-        private final JsonObjectBuilder builder = createObjectBuilder()
-                .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
-                .add(TYPE, TYPE_CATALOG_REQUEST);
+    public static class Builder extends AbstractBuilder<CatalogRequest, CatalogRequest.Builder> {
 
         public static CatalogRequest.Builder newInstance() {
             return new CatalogRequest.Builder();
         }
 
         public CatalogRequest build() {
-            return new CatalogRequest(builder.build());
+            return new CatalogRequest(builder.add(TYPE, TYPE_CATALOG_REQUEST).build());
         }
 
         public CatalogRequest.Builder protocol(String protocol) {
@@ -62,11 +57,6 @@ public class CatalogRequest extends JsonLdObject {
 
         public CatalogRequest.Builder querySpec(QuerySpec querySpec) {
             builder.add(CATALOG_REQUEST_QUERY_SPEC, Json.createObjectBuilder(querySpec.raw()));
-            return this;
-        }
-
-        public CatalogRequest.Builder raw(JsonObject raw) {
-            builder.addAll(Json.createObjectBuilder(raw));
             return this;
         }
     }

--- a/src/main/java/io/thinkit/edc/client/connector/ContractAgreement.java
+++ b/src/main/java/io/thinkit/edc/client/connector/ContractAgreement.java
@@ -6,7 +6,6 @@ import static jakarta.json.Json.createObjectBuilder;
 
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
 
 public class ContractAgreement extends JsonLdObject {
     private static final String TYPE_CONTRACT_AGREEMENT = EDC_NAMESPACE + "ContractAgreement";
@@ -40,23 +39,15 @@ public class ContractAgreement extends JsonLdObject {
         return new Policy(object(CONTRACT_AGREEMENT_POLICY));
     }
 
-    public static class Builder {
-
-        private final JsonObjectBuilder builder = createObjectBuilder()
-                .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
-                .add(TYPE, TYPE_CONTRACT_AGREEMENT);
+    public static class Builder extends AbstractBuilder<ContractAgreement, ContractAgreement.Builder> {
 
         public static ContractAgreement.Builder newInstance() {
             return new ContractAgreement.Builder();
         }
 
         public ContractAgreement build() {
-            return new ContractAgreement(builder.build());
-        }
-
-        public ContractAgreement.Builder id(String id) {
-            builder.add(ID, id);
-            return this;
+            return new ContractAgreement(
+                    builder.add(TYPE, TYPE_CONTRACT_AGREEMENT).build());
         }
 
         public ContractAgreement.Builder providerId(String providerId) {
@@ -89,11 +80,6 @@ public class ContractAgreement extends JsonLdObject {
 
         public ContractAgreement.Builder policy(Policy policy) {
             builder.add(CONTRACT_AGREEMENT_POLICY, Json.createObjectBuilder(policy.raw()));
-            return this;
-        }
-
-        public ContractAgreement.Builder raw(JsonObject raw) {
-            builder.addAll(Json.createObjectBuilder(raw));
             return this;
         }
     }

--- a/src/main/java/io/thinkit/edc/client/connector/ContractDefinition.java
+++ b/src/main/java/io/thinkit/edc/client/connector/ContractDefinition.java
@@ -5,9 +5,7 @@ import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createObjectBuilder;
 import static jakarta.json.stream.JsonCollectors.toJsonArray;
 
-import jakarta.json.Json;
 import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
 import java.util.List;
 
 public class ContractDefinition extends JsonLdObject {
@@ -39,23 +37,15 @@ public class ContractDefinition extends JsonLdObject {
         return longValue(CONTRACT_DEFINITION__CREATED_AT);
     }
 
-    public static class Builder {
-
-        private final JsonObjectBuilder builder = createObjectBuilder()
-                .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
-                .add(TYPE, TYPE_CONTRACT_DEFINITION);
+    public static class Builder extends AbstractBuilder<ContractDefinition, ContractDefinition.Builder> {
 
         public static ContractDefinition.Builder newInstance() {
             return new ContractDefinition.Builder();
         }
 
         public ContractDefinition build() {
-            return new ContractDefinition(builder.build());
-        }
-
-        public ContractDefinition.Builder id(String id) {
-            builder.add(ID, id);
-            return this;
+            return new ContractDefinition(
+                    builder.add(TYPE, TYPE_CONTRACT_DEFINITION).build());
         }
 
         public ContractDefinition.Builder accessPolicyId(String accessPolicyId) {
@@ -76,11 +66,6 @@ public class ContractDefinition extends JsonLdObject {
             builder.add(
                     CONTRACT_DEFINITION_ASSETS_SELECTOR,
                     criteria.stream().map(Criterion::raw).collect(toJsonArray()));
-            return this;
-        }
-
-        public ContractDefinition.Builder raw(JsonObject raw) {
-            builder.addAll(Json.createObjectBuilder(raw));
             return this;
         }
     }

--- a/src/main/java/io/thinkit/edc/client/connector/ContractNegotiation.java
+++ b/src/main/java/io/thinkit/edc/client/connector/ContractNegotiation.java
@@ -5,9 +5,7 @@ import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createObjectBuilder;
 import static jakarta.json.stream.JsonCollectors.toJsonArray;
 
-import jakarta.json.Json;
 import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
 import java.util.List;
 
 public class ContractNegotiation extends JsonLdObject {
@@ -64,23 +62,15 @@ public class ContractNegotiation extends JsonLdObject {
         return longValue(CONTRACT_NEGOTIATION_CREATED_AT);
     }
 
-    public static class Builder {
-
-        private final JsonObjectBuilder builder = createObjectBuilder()
-                .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
-                .add(TYPE, TYPE_CONTRACT_NEGOTIATION);
+    public static class Builder extends AbstractBuilder<ContractNegotiation, ContractNegotiation.Builder> {
 
         public static ContractNegotiation.Builder newInstance() {
             return new ContractNegotiation.Builder();
         }
 
         public ContractNegotiation build() {
-            return new ContractNegotiation(builder.build());
-        }
-
-        public ContractNegotiation.Builder id(String id) {
-            builder.add(ID, id);
-            return this;
+            return new ContractNegotiation(
+                    builder.add(TYPE, TYPE_CONTRACT_NEGOTIATION).build());
         }
 
         public ContractNegotiation.Builder type(String type) {
@@ -136,11 +126,6 @@ public class ContractNegotiation extends JsonLdObject {
             builder.add(
                     CONTRACT_NEGOTIATION_CALLBACK_ADDRESSES,
                     callbackAddresses.stream().map(CallbackAddress::raw).collect(toJsonArray()));
-            return this;
-        }
-
-        public ContractNegotiation.Builder raw(JsonObject raw) {
-            builder.addAll(Json.createObjectBuilder(raw));
             return this;
         }
     }

--- a/src/main/java/io/thinkit/edc/client/connector/ContractOfferDescription.java
+++ b/src/main/java/io/thinkit/edc/client/connector/ContractOfferDescription.java
@@ -6,7 +6,6 @@ import static jakarta.json.Json.createObjectBuilder;
 
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
 
 public class ContractOfferDescription extends JsonLdObject {
     private static final String TYPE_CONTRACT_OFFER = EDC_NAMESPACE + "ContractOfferDescription";
@@ -31,18 +30,15 @@ public class ContractOfferDescription extends JsonLdObject {
         return new Policy(object(CONTRACT_OFFER_POLICY));
     }
 
-    public static class Builder {
-
-        private final JsonObjectBuilder builder = createObjectBuilder()
-                .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
-                .add(TYPE, TYPE_CONTRACT_OFFER);
+    public static class Builder extends AbstractBuilder<ContractOfferDescription, ContractOfferDescription.Builder> {
 
         public static ContractOfferDescription.Builder newInstance() {
             return new ContractOfferDescription.Builder();
         }
 
         public ContractOfferDescription build() {
-            return new ContractOfferDescription(builder.build());
+            return new ContractOfferDescription(
+                    builder.add(TYPE, TYPE_CONTRACT_OFFER).build());
         }
 
         public ContractOfferDescription.Builder id(String id) {

--- a/src/main/java/io/thinkit/edc/client/connector/ContractRequest.java
+++ b/src/main/java/io/thinkit/edc/client/connector/ContractRequest.java
@@ -7,7 +7,6 @@ import static jakarta.json.stream.JsonCollectors.toJsonArray;
 
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
 import java.util.List;
 
 public class ContractRequest extends JsonLdObject {
@@ -44,23 +43,14 @@ public class ContractRequest extends JsonLdObject {
                 .toList();
     }
 
-    public static class Builder {
-
-        private final JsonObjectBuilder builder = createObjectBuilder()
-                .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
-                .add(TYPE, TYPE_CONTRACT_REQUEST);
-
+    public static class Builder extends AbstractBuilder<ContractRequest, ContractRequest.Builder> {
         public static ContractRequest.Builder newInstance() {
             return new ContractRequest.Builder();
         }
+        ;
 
         public ContractRequest build() {
-            return new ContractRequest(builder.build());
-        }
-
-        public ContractRequest.Builder id(String id) {
-            builder.add(ID, id);
-            return this;
+            return new ContractRequest(builder.add(TYPE, TYPE_CONTRACT_REQUEST).build());
         }
 
         public ContractRequest.Builder counterPartyAddress(String counterPartyAddress) {
@@ -94,11 +84,6 @@ public class ContractRequest extends JsonLdObject {
                     CONTRACT_REQUEST_CALLBACK_ADDRESSES,
                     callbackAddresses.stream().map(CallbackAddress::raw).collect(toJsonArray()));
 
-            return this;
-        }
-
-        public ContractRequest.Builder raw(JsonObject raw) {
-            builder.addAll(Json.createObjectBuilder(raw));
             return this;
         }
     }

--- a/src/main/java/io/thinkit/edc/client/connector/DataAddress.java
+++ b/src/main/java/io/thinkit/edc/client/connector/DataAddress.java
@@ -5,7 +5,6 @@ import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createObjectBuilder;
 
 import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
 
 public class DataAddress extends JsonLdObject {
     private static final String TYPE_DATA_ADDRESS = EDC_NAMESPACE + "DataAddress";
@@ -22,27 +21,20 @@ public class DataAddress extends JsonLdObject {
         return new Properties(this.raw());
     }
 
-    public static class Builder {
-
-        private final JsonObjectBuilder builder = createObjectBuilder().add(TYPE, TYPE_DATA_ADDRESS);
+    public static class Builder extends AbstractBuilder<DataAddress, DataAddress.Builder> {
 
         public static DataAddress.Builder newInstance() {
             return new DataAddress.Builder();
         }
 
         public DataAddress build() {
-            return new DataAddress(builder.build());
+            return new DataAddress(builder.add(TYPE, TYPE_DATA_ADDRESS).build());
         }
 
         public DataAddress.Builder type(String type) {
             builder.add(
                     EDC_NAMESPACE + "type",
                     createArrayBuilder().add(createObjectBuilder().add(VALUE, type)));
-            return this;
-        }
-
-        public DataAddress.Builder raw(JsonObject raw) {
-            builder.addAll(createObjectBuilder(raw));
             return this;
         }
     }

--- a/src/main/java/io/thinkit/edc/client/connector/DataPlaneInstance.java
+++ b/src/main/java/io/thinkit/edc/client/connector/DataPlaneInstance.java
@@ -6,7 +6,6 @@ import static jakarta.json.Json.createObjectBuilder;
 
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
 import java.util.List;
 
 public class DataPlaneInstance extends JsonLdObject {
@@ -45,23 +44,15 @@ public class DataPlaneInstance extends JsonLdObject {
         return stringValue(DATAPLANE_INSTANCE_URL);
     }
 
-    public static class Builder {
-
-        private final JsonObjectBuilder builder = createObjectBuilder()
-                .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
-                .add(TYPE, TYPE_DATAPLANE_INSTANCE);
+    public static class Builder extends AbstractBuilder<DataPlaneInstance, DataPlaneInstance.Builder> {
 
         public static DataPlaneInstance.Builder newInstance() {
             return new DataPlaneInstance.Builder();
         }
 
-        public DataPlaneInstance.Builder id(String id) {
-            builder.add(ID, id);
-            return this;
-        }
-
         public DataPlaneInstance build() {
-            return new DataPlaneInstance(builder.build());
+            return new DataPlaneInstance(
+                    builder.add(TYPE, TYPE_DATAPLANE_INSTANCE).build());
         }
 
         public DataPlaneInstance.Builder allowedDestTypes(List<String> allowedDestTypes) {
@@ -92,11 +83,6 @@ public class DataPlaneInstance extends JsonLdObject {
             builder.add(
                     DATAPLANE_INSTANCE_URL,
                     createArrayBuilder().add(createObjectBuilder().add(VALUE, url)));
-            return this;
-        }
-
-        public DataPlaneInstance.Builder raw(JsonObject raw) {
-            builder.addAll(Json.createObjectBuilder(raw));
             return this;
         }
     }

--- a/src/main/java/io/thinkit/edc/client/connector/Dataset.java
+++ b/src/main/java/io/thinkit/edc/client/connector/Dataset.java
@@ -7,7 +7,6 @@ import static jakarta.json.stream.JsonCollectors.toJsonArray;
 
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
 import java.util.List;
 
 public class Dataset extends JsonLdObject {
@@ -32,21 +31,14 @@ public class Dataset extends JsonLdObject {
         return objects(DATASET_DISTRIBUTION).map(Distribution::new).toList();
     }
 
-    public static class Builder {
-
-        private final JsonObjectBuilder builder = createObjectBuilder().add(TYPE, TYPE_DATASET);
+    public static class Builder extends AbstractBuilder<Dataset, Dataset.Builder> {
 
         public static Dataset.Builder newInstance() {
             return new Dataset.Builder();
         }
 
         public Dataset build() {
-            return new Dataset(builder.build());
-        }
-
-        public Dataset.Builder id(String id) {
-            builder.add(ID, id);
-            return this;
+            return new Dataset(builder.add(TYPE, TYPE_DATASET).build());
         }
 
         public Dataset.Builder description(String description) {
@@ -65,11 +57,6 @@ public class Dataset extends JsonLdObject {
             builder.add(
                     DATASET_DISTRIBUTION,
                     distribution.stream().map(Distribution::raw).collect(toJsonArray()));
-            return this;
-        }
-
-        public Dataset.Builder raw(JsonObject raw) {
-            builder.addAll(Json.createObjectBuilder(raw));
             return this;
         }
     }

--- a/src/main/java/io/thinkit/edc/client/connector/DatasetRequest.java
+++ b/src/main/java/io/thinkit/edc/client/connector/DatasetRequest.java
@@ -4,9 +4,7 @@ import static io.thinkit.edc.client.connector.Constants.*;
 import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createObjectBuilder;
 
-import jakarta.json.Json;
 import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
 
 public class DatasetRequest extends JsonLdObject {
     private static final String TYPE_DATASET_REQUEST = EDC_NAMESPACE + "DatasetRequest";
@@ -25,23 +23,14 @@ public class DatasetRequest extends JsonLdObject {
         return stringValue(DATASET_REQUEST_COUNTER_PARTY_ADDRESS);
     }
 
-    public static class Builder {
-
-        private final JsonObjectBuilder builder = createObjectBuilder()
-                .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
-                .add(TYPE, TYPE_DATASET_REQUEST);
+    public static class Builder extends AbstractBuilder<DatasetRequest, DatasetRequest.Builder> {
 
         public static DatasetRequest.Builder newInstance() {
             return new DatasetRequest.Builder();
         }
 
         public DatasetRequest build() {
-            return new DatasetRequest(builder.build());
-        }
-
-        public DatasetRequest.Builder id(String id) {
-            builder.add(ID, id);
-            return this;
+            return new DatasetRequest(builder.add(TYPE, TYPE_DATASET_REQUEST).build());
         }
 
         public DatasetRequest.Builder protocol(String protocol) {
@@ -55,11 +44,6 @@ public class DatasetRequest extends JsonLdObject {
             builder.add(
                     DATASET_REQUEST_COUNTER_PARTY_ADDRESS,
                     createArrayBuilder().add(createObjectBuilder().add(VALUE, counterPartyAddress)));
-            return this;
-        }
-
-        public DatasetRequest.Builder raw(JsonObject raw) {
-            builder.addAll(Json.createObjectBuilder(raw));
             return this;
         }
     }

--- a/src/main/java/io/thinkit/edc/client/connector/JsonLdObject.java
+++ b/src/main/java/io/thinkit/edc/client/connector/JsonLdObject.java
@@ -1,9 +1,11 @@
 package io.thinkit.edc.client.connector;
 
-import static io.thinkit.edc.client.connector.Constants.ID;
-import static io.thinkit.edc.client.connector.Constants.VALUE;
+import static io.thinkit.edc.client.connector.Constants.*;
+import static jakarta.json.Json.createObjectBuilder;
 
+import jakarta.json.Json;
 import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonValue;
 import java.util.stream.Stream;
 
@@ -45,5 +47,24 @@ public class JsonLdObject {
 
     protected Boolean booleanValue(String key) {
         return raw.getJsonArray(key).getJsonObject(0).getBoolean(VALUE);
+    }
+
+    public abstract static class AbstractBuilder<T extends JsonLdObject, B extends AbstractBuilder<T, B>> {
+
+        public final JsonObjectBuilder builder =
+                createObjectBuilder().add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE));
+        public Class<T> c;
+
+        public abstract T build();
+
+        public B id(String id) {
+            builder.add(ID, id);
+            return (B) this;
+        }
+
+        public B raw(JsonObject raw) {
+            builder.addAll(Json.createObjectBuilder(raw));
+            return (B) this;
+        }
     }
 }

--- a/src/main/java/io/thinkit/edc/client/connector/JsonLdObject.java
+++ b/src/main/java/io/thinkit/edc/client/connector/JsonLdObject.java
@@ -53,8 +53,6 @@ public class JsonLdObject {
 
         public final JsonObjectBuilder builder =
                 createObjectBuilder().add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE));
-        public Class<T> c;
-
         public abstract T build();
 
         public B id(String id) {

--- a/src/main/java/io/thinkit/edc/client/connector/Policy.java
+++ b/src/main/java/io/thinkit/edc/client/connector/Policy.java
@@ -7,6 +7,8 @@ import jakarta.json.*;
 import java.util.List;
 
 public class Policy extends JsonLdObject {
+    private static final String TYPE_POLICY = EDC_NAMESPACE + "Policy";
+
 
     public Policy(JsonObject raw) {
         super(raw);
@@ -27,7 +29,7 @@ public class Policy extends JsonLdObject {
         }
 
         public Policy build() {
-            return new Policy(builder.add(TYPE, EDC_NAMESPACE + "Policy").build());
+            return new Policy(builder.add(TYPE, TYPE_POLICY).build());
         }
     }
 }

--- a/src/main/java/io/thinkit/edc/client/connector/Policy.java
+++ b/src/main/java/io/thinkit/edc/client/connector/Policy.java
@@ -2,7 +2,6 @@ package io.thinkit.edc.client.connector;
 
 import static io.thinkit.edc.client.connector.Constants.*;
 import static io.thinkit.edc.client.connector.Constants.EDC_NAMESPACE;
-import static jakarta.json.Json.createObjectBuilder;
 
 import jakarta.json.*;
 import java.util.List;
@@ -21,22 +20,14 @@ public class Policy extends JsonLdObject {
         return objects(key).toList();
     }
 
-    public static class Builder {
-        private final JsonObjectBuilder raw = createObjectBuilder()
-                .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
-                .add(TYPE, EDC_NAMESPACE + "Policy");
+    public static class Builder extends AbstractBuilder<Policy, Policy.Builder> {
 
         public static Policy.Builder newInstance() {
             return new Policy.Builder();
         }
 
         public Policy build() {
-            return new Policy(raw.build());
-        }
-
-        public Policy.Builder raw(JsonObject raw) {
-            this.raw.addAll(createObjectBuilder(raw));
-            return this;
+            return new Policy(builder.add(TYPE, EDC_NAMESPACE + "Policy").build());
         }
     }
 }

--- a/src/main/java/io/thinkit/edc/client/connector/PolicyDefinition.java
+++ b/src/main/java/io/thinkit/edc/client/connector/PolicyDefinition.java
@@ -1,11 +1,9 @@
 package io.thinkit.edc.client.connector;
 
 import static io.thinkit.edc.client.connector.Constants.*;
-import static jakarta.json.Json.createObjectBuilder;
 
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
 
 public class PolicyDefinition extends JsonLdObject {
     private static final String POLICY_DEFINITION_POLICY = EDC_NAMESPACE + "policy";
@@ -23,32 +21,19 @@ public class PolicyDefinition extends JsonLdObject {
         return longValue(POLICY_DEFINITION_CREATED_AT);
     }
 
-    public static class Builder {
-
-        private final JsonObjectBuilder builder = createObjectBuilder()
-                .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
-                .add(TYPE, EDC_NAMESPACE + "PolicyDefinition");
+    public static class Builder extends AbstractBuilder<PolicyDefinition, PolicyDefinition.Builder> {
 
         public static PolicyDefinition.Builder newInstance() {
             return new PolicyDefinition.Builder();
         }
 
         public PolicyDefinition build() {
-            return new PolicyDefinition(builder.build());
-        }
-
-        public PolicyDefinition.Builder id(String id) {
-            builder.add(ID, id);
-            return this;
+            return new PolicyDefinition(
+                    builder.add(TYPE, EDC_NAMESPACE + "PolicyDefinition").build());
         }
 
         public PolicyDefinition.Builder policy(Policy policy) {
             builder.add(POLICY_DEFINITION_POLICY, Json.createObjectBuilder(policy.raw()));
-            return this;
-        }
-
-        public PolicyDefinition.Builder raw(JsonObject raw) {
-            builder.addAll(Json.createObjectBuilder(raw));
             return this;
         }
     }

--- a/src/main/java/io/thinkit/edc/client/connector/QuerySpec.java
+++ b/src/main/java/io/thinkit/edc/client/connector/QuerySpec.java
@@ -1,17 +1,13 @@
 package io.thinkit.edc.client.connector;
 
-import static io.thinkit.edc.client.connector.Constants.CONTEXT;
 import static io.thinkit.edc.client.connector.Constants.EDC_NAMESPACE;
 import static io.thinkit.edc.client.connector.Constants.TYPE;
 import static io.thinkit.edc.client.connector.Constants.VALUE;
-import static io.thinkit.edc.client.connector.Constants.VOCAB;
 import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createObjectBuilder;
 import static jakarta.json.stream.JsonCollectors.toJsonArray;
 
-import jakarta.json.Json;
 import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
 import java.util.List;
 
 public class QuerySpec extends JsonLdObject {
@@ -49,18 +45,13 @@ public class QuerySpec extends JsonLdObject {
                 .toList();
     }
 
-    public static final class Builder {
-
-        private final JsonObjectBuilder builder = createObjectBuilder()
-                .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
-                .add(TYPE, TYPE_QUERY_SPEC);
-
+    public static final class Builder extends AbstractBuilder<QuerySpec, QuerySpec.Builder> {
         public static Builder newInstance() {
             return new Builder();
         }
 
         public QuerySpec build() {
-            return new QuerySpec(builder.build());
+            return new QuerySpec(builder.add(TYPE, TYPE_QUERY_SPEC).build());
         }
 
         public Builder offset(int offset) {
@@ -90,11 +81,6 @@ public class QuerySpec extends JsonLdObject {
         public Builder filterExpression(List<Criterion> criteria) {
             builder.add(
                     "filterExpression", criteria.stream().map(Criterion::raw).collect(toJsonArray()));
-            return this;
-        }
-
-        public Builder raw(JsonObject raw) {
-            builder.addAll(Json.createObjectBuilder(raw));
             return this;
         }
     }

--- a/src/main/java/io/thinkit/edc/client/connector/SelectionRequest.java
+++ b/src/main/java/io/thinkit/edc/client/connector/SelectionRequest.java
@@ -6,7 +6,6 @@ import static jakarta.json.Json.createObjectBuilder;
 
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
 
 public class SelectionRequest extends JsonLdObject {
     private static final String TYPE_SELECTION_REQUEST = EDC_NAMESPACE + "SelectionRequest";
@@ -30,18 +29,15 @@ public class SelectionRequest extends JsonLdObject {
         return stringValue(SELECTION_REQUEST_STRATEGY);
     }
 
-    public static class Builder {
-
-        private final JsonObjectBuilder builder = createObjectBuilder()
-                .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
-                .add(TYPE, TYPE_SELECTION_REQUEST);
+    public static class Builder extends AbstractBuilder<SelectionRequest, SelectionRequest.Builder> {
 
         public static SelectionRequest.Builder newInstance() {
             return new SelectionRequest.Builder();
         }
 
         public SelectionRequest build() {
-            return new SelectionRequest(builder.build());
+            return new SelectionRequest(
+                    builder.add(TYPE, TYPE_SELECTION_REQUEST).build());
         }
 
         public SelectionRequest.Builder destination(DataAddress destination) {
@@ -58,11 +54,6 @@ public class SelectionRequest extends JsonLdObject {
             builder.add(
                     SELECTION_REQUEST_STRATEGY,
                     createArrayBuilder().add(createObjectBuilder().add(VALUE, strategy)));
-            return this;
-        }
-
-        public SelectionRequest.Builder raw(JsonObject raw) {
-            builder.addAll(Json.createObjectBuilder(raw));
             return this;
         }
     }

--- a/src/main/java/io/thinkit/edc/client/connector/Service.java
+++ b/src/main/java/io/thinkit/edc/client/connector/Service.java
@@ -4,9 +4,7 @@ import static io.thinkit.edc.client.connector.Constants.*;
 import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createObjectBuilder;
 
-import jakarta.json.Json;
 import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
 
 public class Service extends JsonLdObject {
     private static final String TYPE_SERVICE = DCAT_NAMESPACE + "DataService";
@@ -25,21 +23,14 @@ public class Service extends JsonLdObject {
         return stringValue(SERVICE_ENDPOINT_URL);
     }
 
-    public static class Builder {
-
-        private final JsonObjectBuilder builder = createObjectBuilder().add(TYPE, TYPE_SERVICE);
+    public static class Builder extends AbstractBuilder<Service, Service.Builder> {
 
         public static Service.Builder newInstance() {
             return new Service.Builder();
         }
 
         public Service build() {
-            return new Service(builder.build());
-        }
-
-        public Service.Builder id(String id) {
-            builder.add(ID, id);
-            return this;
+            return new Service(builder.add(TYPE, TYPE_SERVICE).build());
         }
 
         public Service.Builder terms(String terms) {
@@ -53,11 +44,6 @@ public class Service extends JsonLdObject {
             builder.add(
                     SERVICE_ENDPOINT_URL,
                     createArrayBuilder().add(createObjectBuilder().add(VALUE, endpointUrl)));
-            return this;
-        }
-
-        public Service.Builder raw(JsonObject raw) {
-            builder.addAll(Json.createObjectBuilder(raw));
             return this;
         }
     }

--- a/src/main/java/io/thinkit/edc/client/connector/TerminateNegotiation.java
+++ b/src/main/java/io/thinkit/edc/client/connector/TerminateNegotiation.java
@@ -4,9 +4,7 @@ import static io.thinkit.edc.client.connector.Constants.*;
 import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createObjectBuilder;
 
-import jakarta.json.Json;
 import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
 
 public class TerminateNegotiation extends JsonLdObject {
     private static final String TYPE_TERMINATE_NEGOTIATION = EDC_NAMESPACE + "TerminateNegotiation";
@@ -20,34 +18,21 @@ public class TerminateNegotiation extends JsonLdObject {
         return stringValue(TERMINATE_NEGOTIATION_REASON);
     }
 
-    public static class Builder {
-
-        private final JsonObjectBuilder builder = createObjectBuilder()
-                .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
-                .add(TYPE, TYPE_TERMINATE_NEGOTIATION);
+    public static class Builder extends AbstractBuilder<TerminateNegotiation, TerminateNegotiation.Builder> {
 
         public static TerminateNegotiation.Builder newInstance() {
             return new TerminateNegotiation.Builder();
         }
 
         public TerminateNegotiation build() {
-            return new TerminateNegotiation(builder.build());
-        }
-
-        public TerminateNegotiation.Builder id(String id) {
-            builder.add(ID, id);
-            return this;
+            return new TerminateNegotiation(
+                    builder.add(TYPE, TYPE_TERMINATE_NEGOTIATION).build());
         }
 
         public TerminateNegotiation.Builder reason(String reason) {
             builder.add(
                     TERMINATE_NEGOTIATION_REASON,
                     createArrayBuilder().add(createObjectBuilder().add(VALUE, reason)));
-            return this;
-        }
-
-        public TerminateNegotiation.Builder raw(JsonObject raw) {
-            builder.addAll(Json.createObjectBuilder(raw));
             return this;
         }
     }

--- a/src/main/java/io/thinkit/edc/client/connector/TerminateTransfer.java
+++ b/src/main/java/io/thinkit/edc/client/connector/TerminateTransfer.java
@@ -4,9 +4,7 @@ import static io.thinkit.edc.client.connector.Constants.*;
 import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createObjectBuilder;
 
-import jakarta.json.Json;
 import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
 
 public class TerminateTransfer extends JsonLdObject {
     private static final String TYPE_TERMINATE_TRANSFER = EDC_NAMESPACE + "TerminateTransfer";
@@ -20,34 +18,21 @@ public class TerminateTransfer extends JsonLdObject {
         return stringValue(TERMINATE_TRANSFER_REASON);
     }
 
-    public static class Builder {
-
-        private final JsonObjectBuilder builder = createObjectBuilder()
-                .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
-                .add(TYPE, TYPE_TERMINATE_TRANSFER);
+    public static class Builder extends AbstractBuilder<TerminateTransfer, TerminateTransfer.Builder> {
 
         public static TerminateTransfer.Builder newInstance() {
             return new TerminateTransfer.Builder();
         }
 
         public TerminateTransfer build() {
-            return new TerminateTransfer(builder.build());
-        }
-
-        public TerminateTransfer.Builder id(String id) {
-            builder.add(ID, id);
-            return this;
+            return new TerminateTransfer(
+                    builder.add(TYPE, TYPE_TERMINATE_TRANSFER).build());
         }
 
         public TerminateTransfer.Builder reason(String reason) {
             builder.add(
                     TERMINATE_TRANSFER_REASON,
                     createArrayBuilder().add(createObjectBuilder().add(VALUE, reason)));
-            return this;
-        }
-
-        public TerminateTransfer.Builder raw(JsonObject raw) {
-            builder.addAll(Json.createObjectBuilder(raw));
             return this;
         }
     }

--- a/src/main/java/io/thinkit/edc/client/connector/TransferProcess.java
+++ b/src/main/java/io/thinkit/edc/client/connector/TransferProcess.java
@@ -5,9 +5,7 @@ import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createObjectBuilder;
 import static jakarta.json.stream.JsonCollectors.toJsonArray;
 
-import jakarta.json.Json;
 import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
 import java.util.List;
 import java.util.Map;
 
@@ -80,23 +78,14 @@ public class TransferProcess extends JsonLdObject {
         return longValue(TRANSFER_PROCESS_CREATED_AT);
     }
 
-    public static class Builder {
-
-        private final JsonObjectBuilder builder = createObjectBuilder()
-                .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
-                .add(TYPE, TYPE_TRANSFER_PROCESS);
+    public static class Builder extends AbstractBuilder<TransferProcess, TransferProcess.Builder> {
 
         public static TransferProcess.Builder newInstance() {
             return new TransferProcess.Builder();
         }
 
         public TransferProcess build() {
-            return new TransferProcess(builder.build());
-        }
-
-        public TransferProcess.Builder id(String id) {
-            builder.add(ID, id);
-            return this;
+            return new TransferProcess(builder.add(TYPE, TYPE_TRANSFER_PROCESS).build());
         }
 
         public TransferProcess.Builder correlationId(String correlationId) {
@@ -176,11 +165,6 @@ public class TransferProcess extends JsonLdObject {
             builder.add(
                     TRANSFER_PROCESS_CALLBACK_ADDRESSES,
                     callbackAddresses.stream().map(CallbackAddress::raw).collect(toJsonArray()));
-            return this;
-        }
-
-        public TransferProcess.Builder raw(JsonObject raw) {
-            builder.addAll(Json.createObjectBuilder(raw));
             return this;
         }
     }

--- a/src/main/java/io/thinkit/edc/client/connector/TransferRequest.java
+++ b/src/main/java/io/thinkit/edc/client/connector/TransferRequest.java
@@ -5,9 +5,7 @@ import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createObjectBuilder;
 import static jakarta.json.stream.JsonCollectors.toJsonArray;
 
-import jakarta.json.Json;
 import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
 import java.util.List;
 import java.util.Map;
 
@@ -60,23 +58,14 @@ public class TransferRequest extends JsonLdObject {
                 .toList();
     }
 
-    public static class Builder {
-
-        private final JsonObjectBuilder builder = createObjectBuilder()
-                .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
-                .add(TYPE, TYPE_TRANSFER_REQUEST);
+    public static class Builder extends AbstractBuilder<TransferRequest, TransferRequest.Builder> {
 
         public static TransferRequest.Builder newInstance() {
             return new TransferRequest.Builder();
         }
 
         public TransferRequest build() {
-            return new TransferRequest(builder.build());
-        }
-
-        public TransferRequest.Builder id(String id) {
-            builder.add(ID, id);
-            return this;
+            return new TransferRequest(builder.add(TYPE, TYPE_TRANSFER_REQUEST).build());
         }
 
         public TransferRequest.Builder protocol(String protocol) {
@@ -135,11 +124,6 @@ public class TransferRequest extends JsonLdObject {
             builder.add(
                     TRANSFER_REQUEST_CALLBACK_ADDRESSES,
                     callbackAddresses.stream().map(CallbackAddress::raw).collect(toJsonArray()));
-            return this;
-        }
-
-        public TransferRequest.Builder raw(JsonObject raw) {
-            builder.addAll(Json.createObjectBuilder(raw));
             return this;
         }
     }

--- a/src/main/java/io/thinkit/edc/client/connector/TransferState.java
+++ b/src/main/java/io/thinkit/edc/client/connector/TransferState.java
@@ -4,9 +4,7 @@ import static io.thinkit.edc.client.connector.Constants.*;
 import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createObjectBuilder;
 
-import jakarta.json.Json;
 import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
 
 public class TransferState extends JsonLdObject {
     private static final String TYPE_TRANSFER_STATE = EDC_NAMESPACE + "TransferState";
@@ -20,29 +18,20 @@ public class TransferState extends JsonLdObject {
         return stringValue(TRANSFER_PROCESS_STATE);
     }
 
-    public static class Builder {
-
-        private final JsonObjectBuilder builder = createObjectBuilder()
-                .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
-                .add(TYPE, TYPE_TRANSFER_STATE);
+    public static class Builder extends AbstractBuilder<TransferState, TransferState.Builder> {
 
         public static TransferState.Builder newInstance() {
             return new TransferState.Builder();
         }
 
         public TransferState build() {
-            return new TransferState(builder.build());
+            return new TransferState(builder.add(TYPE, TYPE_TRANSFER_STATE).build());
         }
 
         public TransferState.Builder state(String state) {
             builder.add(
                     TRANSFER_PROCESS_STATE,
                     createArrayBuilder().add(createObjectBuilder().add(VALUE, state)));
-            return this;
-        }
-
-        public TransferState.Builder raw(JsonObject raw) {
-            builder.addAll(Json.createObjectBuilder(raw));
             return this;
         }
     }


### PR DESCRIPTION
In this PR, we added an abstract builder in the JsonLdObject class to remove duplications between builders