### PR TITLE
build: automate release preparation phase

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,42 @@
+name: draft-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'SemVer that will be used for publishing (e.g. "0.0.1")'
+        required: true
+        type: string
+
+jobs:
+  Prepare-Release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create release/${{ github.event.inputs.version }} branch
+        run: |
+          git config user.name "think-it-account"
+          git config user.email "technical@think-it.io"
+          
+          git checkout -b release/${{ inputs.version }}
+          sed -i 's/version=.*/version=${{ github.event.inputs.version }}/g' gradle.properties
+          git add .
+          git commit -m "Prepare release ${{ github.event.inputs.version }}"
+          git push origin release/${{ github.event.inputs.version }}
+      - name: Create pull request
+        uses: thomaseizinger/create-pull-request@1.3.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          head: release/${{ github.event.inputs.version }}
+          base: releases
+          title: Release version ${{ github.event.inputs.version }}
+          reviewers: ${{ github.actor }}
+          body: |-
+            This PR was created in response to a manual trigger of the [release workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+            Versions have been bumped in [commit ${{ steps.make-commit.outputs.commit }}](${{ steps.make-commit.outputs.commit }}).
+
+            Merging this PR will create a GitHub release and upload any assets that are created as part of the release build.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,24 +1,17 @@
 # Release
 
-Currently the release process is not fully automated, here's the current process described step by step used to release 
-version `0.0.1`
+Currently, the release process is not fully automated, here's the current process described.
 
 ## Preparation
 
-Creation of the release branch and update version to `0.0.1`
+Launch the [`draft-release`](https://github.com/Think-iT-Labs/edc-connector-client-java/actions/workflows/draft-release.yml)
+workflow, setting the version to be released.
+At the end of the workflow there will be an open PR that wants to merge the specific version release branch into the 
+`releases` one.
 
-```shell
-git checkout -b release/0.0.1
-sed -i 's/version=.*/version=0.0.1/g' gradle.properties
-git add .
-git commit -m "Prepare release 0.0.1"
-git push origin release/0.0.1
-```
+## Merge PR
 
-## Pull request
-
-After push, a pull request was manually created, from `release/0.0.1` to `releases`.
-After merge, a new `publish` flow has been automatically triggered and the artifact has been uploaded to maven central.
+After merging the PR, a new `publish` flow will be automatically triggered and the artifact will be uploaded to maven central.
 
 ## Tag publication
 


### PR DESCRIPTION
### What
Automates the preparation phase for the release

### How
Setting up a workflow that, giving a version number, will create a new release branch and a PR for merging that branch into the `releases` branch.

Closes #90 