### PR TITLE
feat: provide extensibility capabilities

### DIFF
--- a/src/main/java/io/thinkit/edc/client/connector/EdcClientContext.java
+++ b/src/main/java/io/thinkit/edc/client/connector/EdcClientContext.java
@@ -1,0 +1,15 @@
+package io.thinkit.edc.client.connector;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.util.function.UnaryOperator;
+
+/**
+ * Provides base services to be used in a {@link EdcResource} component
+ */
+public record EdcClientContext(
+        EdcClientUrls edcClientUrls,
+        ObjectMapper objectMapper,
+        HttpClient httpClient,
+        UnaryOperator<HttpRequest.Builder> interceptor) {}

--- a/src/main/java/io/thinkit/edc/client/connector/EdcClientUrls.java
+++ b/src/main/java/io/thinkit/edc/client/connector/EdcClientUrls.java
@@ -1,0 +1,6 @@
+package io.thinkit.edc.client.connector;
+
+/**
+ * Represent the base EDC api endpoints to be used in the {@link EdcResource}
+ */
+public record EdcClientUrls(String management, String observability, String catalogCache, String identityUrl) {}

--- a/src/main/java/io/thinkit/edc/client/connector/EdcConnectorClient.java
+++ b/src/main/java/io/thinkit/edc/client/connector/EdcConnectorClient.java
@@ -1,9 +1,27 @@
 package io.thinkit.edc.client.connector;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.thinkit.edc.client.connector.services.*;
+import io.thinkit.edc.client.connector.services.ApplicationObservability;
+import io.thinkit.edc.client.connector.services.Assets;
+import io.thinkit.edc.client.connector.services.CatalogCache;
+import io.thinkit.edc.client.connector.services.Catalogs;
+import io.thinkit.edc.client.connector.services.ContractAgreements;
+import io.thinkit.edc.client.connector.services.ContractDefinitions;
+import io.thinkit.edc.client.connector.services.ContractNegotiations;
+import io.thinkit.edc.client.connector.services.Dataplanes;
+import io.thinkit.edc.client.connector.services.Did;
+import io.thinkit.edc.client.connector.services.EdrCache;
+import io.thinkit.edc.client.connector.services.KeyPairs;
+import io.thinkit.edc.client.connector.services.Participants;
+import io.thinkit.edc.client.connector.services.PolicyDefinitions;
+import io.thinkit.edc.client.connector.services.Secrets;
+import io.thinkit.edc.client.connector.services.TransferProcesses;
+import io.thinkit.edc.client.connector.services.VerifiableCredentials;
+
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.UnaryOperator;
 
 public class EdcConnectorClient {
@@ -16,6 +34,7 @@ public class EdcConnectorClient {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private UnaryOperator<HttpRequest.Builder> interceptor = UnaryOperator.identity();
+    private final Map<Class<? extends EdcResource>, ResourceCreator> resourceCreators = new HashMap<>();
 
     public static EdcConnectorClient newInstance() {
         return newBuilder().build();
@@ -121,14 +140,14 @@ public class EdcConnectorClient {
     public VerifiableCredentials verifiableCredentials() {
         if (identityUrl == null) {
             throw new IllegalArgumentException(
-                    "Cannot instantiate verifiableCredentials client without the identity url");
+                    "Cannot instantiate verifiableCredentials client without the identityUrl url");
         }
         return new VerifiableCredentials(identityUrl, httpClient, interceptor, objectMapper);
     }
 
     public Did did() {
         if (identityUrl == null) {
-            throw new IllegalArgumentException("Cannot instantiate Did client without the identity url");
+            throw new IllegalArgumentException("Cannot instantiate Did client without the identityUrl url");
         }
         return new Did(identityUrl, httpClient, interceptor, objectMapper);
     }
@@ -145,6 +164,27 @@ public class EdcConnectorClient {
             throw new IllegalArgumentException("Cannot instantiate Did client without the identity url");
         }
         return new Participants(identityUrl, httpClient, interceptor, objectMapper);
+    }
+
+    public <T extends EdcResource> T service(Class<T> resourceClass) {
+        var resourceCreator = resourceCreators.get(resourceClass);
+        if (resourceCreator == null) {
+            throw new IllegalArgumentException("No resource creator of type %s is registered on the client"
+                    .formatted(resourceClass.getSimpleName()));
+        }
+        var resource = resourceCreator.create(createContext());
+        if (!resourceClass.isInstance(resource)) {
+            throw new IllegalArgumentException("Resource %s cannot be cast to %s".formatted(resource, resourceClass));
+        }
+        return resourceClass.cast(resource);
+    }
+
+    private EdcClientContext createContext() {
+        return new EdcClientContext(
+                new EdcClientUrls(managementUrl, observabilityUrl, catalogCacheUrl, identityUrl),
+                objectMapper,
+                httpClient,
+                interceptor);
     }
 
     public static class Builder {
@@ -178,6 +218,11 @@ public class EdcConnectorClient {
 
         public Builder interceptor(UnaryOperator<HttpRequest.Builder> interceptor) {
             client.interceptor = interceptor;
+            return this;
+        }
+
+        public Builder extendWith(Class<? extends EdcResource> resourceClass, ResourceCreator resourceCreator) {
+            client.resourceCreators.put(resourceClass, resourceCreator);
             return this;
         }
 

--- a/src/main/java/io/thinkit/edc/client/connector/EdcConnectorClient.java
+++ b/src/main/java/io/thinkit/edc/client/connector/EdcConnectorClient.java
@@ -140,14 +140,14 @@ public class EdcConnectorClient {
     public VerifiableCredentials verifiableCredentials() {
         if (identityUrl == null) {
             throw new IllegalArgumentException(
-                    "Cannot instantiate verifiableCredentials client without the identityUrl url");
+                    "Cannot instantiate verifiableCredentials client without the identity url");
         }
         return new VerifiableCredentials(identityUrl, httpClient, interceptor, objectMapper);
     }
 
     public Did did() {
         if (identityUrl == null) {
-            throw new IllegalArgumentException("Cannot instantiate Did client without the identityUrl url");
+            throw new IllegalArgumentException("Cannot instantiate Did client without the identity url");
         }
         return new Did(identityUrl, httpClient, interceptor, objectMapper);
     }

--- a/src/main/java/io/thinkit/edc/client/connector/EdcConnectorClient.java
+++ b/src/main/java/io/thinkit/edc/client/connector/EdcConnectorClient.java
@@ -166,7 +166,7 @@ public class EdcConnectorClient {
         return new Participants(identityUrl, httpClient, interceptor, objectMapper);
     }
 
-    public <T extends EdcResource> T service(Class<T> resourceClass) {
+    public <T extends EdcResource> T resource(Class<T> resourceClass) {
         var resourceCreator = resourceCreators.get(resourceClass);
         if (resourceCreator == null) {
             throw new IllegalArgumentException("No resource creator of type %s is registered on the client"
@@ -221,7 +221,7 @@ public class EdcConnectorClient {
             return this;
         }
 
-        public Builder extendWith(Class<? extends EdcResource> resourceClass, ResourceCreator resourceCreator) {
+        public Builder with(Class<? extends EdcResource> resourceClass, ResourceCreator resourceCreator) {
             client.resourceCreators.put(resourceClass, resourceCreator);
             return this;
         }

--- a/src/main/java/io/thinkit/edc/client/connector/EdcResource.java
+++ b/src/main/java/io/thinkit/edc/client/connector/EdcResource.java
@@ -1,0 +1,13 @@
+package io.thinkit.edc.client.connector;
+
+/**
+ * Represent an EDC endpoint resource
+ */
+public abstract class EdcResource {
+
+    protected final EdcClientContext context;
+
+    protected EdcResource(EdcClientContext context) {
+        this.context = context;
+    }
+}

--- a/src/main/java/io/thinkit/edc/client/connector/ResourceCreator.java
+++ b/src/main/java/io/thinkit/edc/client/connector/ResourceCreator.java
@@ -1,0 +1,8 @@
+package io.thinkit.edc.client.connector;
+
+/**
+ * Represent a {@link EdcResource} constructor, with a {@link EdcClientContext} passed.
+ */
+public interface ResourceCreator {
+    EdcResource create(EdcClientContext context);
+}

--- a/src/test/java/io/thinkit/edc/client/connector/EdcConnectorClientTest.java
+++ b/src/test/java/io/thinkit/edc/client/connector/EdcConnectorClientTest.java
@@ -1,9 +1,9 @@
 package io.thinkit.edc.client.connector;
 
+import org.junit.jupiter.api.Test;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import org.junit.jupiter.api.Test;
 
 public class EdcConnectorClientTest {
 
@@ -28,17 +28,17 @@ public class EdcConnectorClientTest {
     @Test
     void should_register_extension_resources() {
         var client = EdcConnectorClient.newBuilder()
-                .extendWith(ExtensionService.class, ExtensionService::new)
+                .with(ExtensionResource.class, ExtensionResource::new)
                 .build();
 
-        var extensionService = client.service(ExtensionService.class);
+        var extension = client.resource(ExtensionResource.class);
 
-        assertThat(extensionService.doStuff()).isEqualTo("done");
+        assertThat(extension.doStuff()).isEqualTo("done");
     }
 
-    private static class ExtensionService extends EdcResource {
+    private static class ExtensionResource extends EdcResource {
 
-        protected ExtensionService(EdcClientContext context) {
+        protected ExtensionResource(EdcClientContext context) {
             super(context);
         }
 

--- a/src/test/java/io/thinkit/edc/client/connector/EdcConnectorClientTest.java
+++ b/src/test/java/io/thinkit/edc/client/connector/EdcConnectorClientTest.java
@@ -24,4 +24,26 @@ public class EdcConnectorClientTest {
 
         assertThatThrownBy(client::assets).isInstanceOf(IllegalArgumentException.class);
     }
+
+    @Test
+    void should_register_extension_resources() {
+        var client = EdcConnectorClient.newBuilder()
+                .extendWith(ExtensionService.class, ExtensionService::new)
+                .build();
+
+        var extensionService = client.service(ExtensionService.class);
+
+        assertThat(extensionService.doStuff()).isEqualTo("done");
+    }
+
+    private static class ExtensionService extends EdcResource {
+
+        protected ExtensionService(EdcClientContext context) {
+            super(context);
+        }
+
+        public String doStuff() {
+            return "done";
+        }
+    }
 }


### PR DESCRIPTION
### What
provides extensibility capabilities to the client, by introducing the `EdcResource` abstract class.
By extending it, a constructor that gets a `EdcContext` instance is passed. That one contains all the services that could be useful (http client, object mapper, urls...).

### Why
It would be useful to cover custom extensions 

### Notes
I didn't use the "service" term currently used in the package name because I think that's too vague, while "resource" better represent the point of view of a RESTful API.

This PR solves a single task in #174, other PRs will come.


Part of #174 

Added @fdionisi as optional reviewer as he already implemented similar functionality in the TS client