### PR TITLE
refactor: adapt management resource to the new spi

### DIFF
--- a/src/main/java/io/thinkit/edc/client/connector/EdcClientContext.java
+++ b/src/main/java/io/thinkit/edc/client/connector/EdcClientContext.java
@@ -1,15 +1,10 @@
 package io.thinkit.edc.client.connector;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.util.function.UnaryOperator;
+import io.thinkit.edc.client.connector.resource.EdcResource;
+import io.thinkit.edc.client.connector.services.EdcApiHttpClient;
 
 /**
  * Provides base services to be used in a {@link EdcResource} component
  */
-public record EdcClientContext(
-        EdcClientUrls edcClientUrls,
-        ObjectMapper objectMapper,
-        HttpClient httpClient,
-        UnaryOperator<HttpRequest.Builder> interceptor) {}
+public record EdcClientContext(EdcClientUrls urls, ObjectMapper objectMapper, EdcApiHttpClient httpClient) {}

--- a/src/main/java/io/thinkit/edc/client/connector/EdcClientUrls.java
+++ b/src/main/java/io/thinkit/edc/client/connector/EdcClientUrls.java
@@ -1,5 +1,7 @@
 package io.thinkit.edc.client.connector;
 
+import io.thinkit.edc.client.connector.resource.EdcResource;
+
 /**
  * Represent the base EDC api endpoints to be used in the {@link EdcResource}
  */

--- a/src/main/java/io/thinkit/edc/client/connector/ResourceCreator.java
+++ b/src/main/java/io/thinkit/edc/client/connector/ResourceCreator.java
@@ -1,5 +1,7 @@
 package io.thinkit.edc.client.connector;
 
+import io.thinkit.edc.client.connector.resource.EdcResource;
+
 /**
  * Represent a {@link EdcResource} constructor, with a {@link EdcClientContext} passed.
  */

--- a/src/main/java/io/thinkit/edc/client/connector/resource/EdcResource.java
+++ b/src/main/java/io/thinkit/edc/client/connector/resource/EdcResource.java
@@ -1,4 +1,6 @@
-package io.thinkit.edc.client.connector;
+package io.thinkit.edc.client.connector.resource;
+
+import io.thinkit.edc.client.connector.EdcClientContext;
 
 /**
  * Represent an EDC endpoint resource

--- a/src/main/java/io/thinkit/edc/client/connector/resource/management/ManagementResource.java
+++ b/src/main/java/io/thinkit/edc/client/connector/resource/management/ManagementResource.java
@@ -1,0 +1,18 @@
+package io.thinkit.edc.client.connector.resource.management;
+
+import io.thinkit.edc.client.connector.EdcClientContext;
+import io.thinkit.edc.client.connector.resource.EdcResource;
+
+public class ManagementResource extends EdcResource {
+
+    protected final String managementUrl;
+
+    protected ManagementResource(EdcClientContext context) {
+        super(context);
+        managementUrl = context.urls().management();
+        if (managementUrl == null) {
+            throw new IllegalArgumentException("Cannot instantiate %s client without the management url"
+                    .formatted(getClass().getSimpleName()));
+        }
+    }
+}

--- a/src/main/java/io/thinkit/edc/client/connector/services/Assets.java
+++ b/src/main/java/io/thinkit/edc/client/connector/services/Assets.java
@@ -4,98 +4,89 @@ import static io.thinkit.edc.client.connector.utils.Constants.ID;
 import static io.thinkit.edc.client.connector.utils.JsonLdUtil.compact;
 import static java.net.http.HttpRequest.BodyPublishers.ofString;
 
+import io.thinkit.edc.client.connector.EdcClientContext;
 import io.thinkit.edc.client.connector.model.Asset;
 import io.thinkit.edc.client.connector.model.QuerySpec;
 import io.thinkit.edc.client.connector.model.Result;
+import io.thinkit.edc.client.connector.resource.management.ManagementResource;
 import io.thinkit.edc.client.connector.utils.JsonLdUtil;
 import jakarta.json.JsonArray;
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.UnaryOperator;
 
-public class Assets {
+public class Assets extends ManagementResource {
     private final String url;
-    private final EdcApiHttpClient edcApiHttpClient;
 
-    public Assets(String url, HttpClient httpClient, UnaryOperator<HttpRequest.Builder> interceptor) {
-        edcApiHttpClient = new EdcApiHttpClient(httpClient, interceptor);
-        this.url = "%s/v3/assets".formatted(url);
+    public Assets(EdcClientContext context) {
+        super(context);
+        url = "%s/v3/assets".formatted(managementUrl);
     }
 
     public Result<Asset> get(String id) {
         var requestBuilder = getRequestBuilder(id);
 
-        return this.edcApiHttpClient
-                .send(requestBuilder)
-                .map(JsonLdUtil::expand)
-                .map(this::getAsset);
+        return context.httpClient().send(requestBuilder).map(JsonLdUtil::expand).map(this::getAsset);
     }
 
     public CompletableFuture<Result<Asset>> getAsync(String id) {
         var requestBuilder = getRequestBuilder(id);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
                 .map(this::getAsset));
     }
 
     public Result<String> create(Asset input) {
         var requestBuilder = createRequestBuilder(input);
 
-        return this.edcApiHttpClient
-                .send(requestBuilder)
-                .map(JsonLdUtil::expand)
-                .map(content -> content.getJsonObject(0).getString(ID));
+        return context.httpClient().send(requestBuilder).map(JsonLdUtil::expand).map(content -> content.getJsonObject(0)
+                .getString(ID));
     }
 
     public CompletableFuture<Result<String>> createAsync(Asset input) {
         var requestBuilder = createRequestBuilder(input);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
                 .map(content -> content.getJsonObject(0).getString(ID)));
     }
 
     public Result<String> update(Asset input) {
         var requestBuilder = updateRequestBuilder(input);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(result -> input.id());
+        return context.httpClient().send(requestBuilder).map(result -> input.id());
     }
 
     public CompletableFuture<Result<String>> updateAsync(Asset input) {
 
         var requestBuilder = updateRequestBuilder(input);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(content -> input.id()));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(content -> input.id()));
     }
 
     public Result<String> delete(String id) {
         var requestBuilder = deleteRequestBuilder(id);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(result -> id);
+        return context.httpClient().send(requestBuilder).map(result -> id);
     }
 
     public CompletableFuture<Result<String>> deleteAsync(String id) {
         var requestBuilder = deleteRequestBuilder(id);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(content -> id));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(content -> id));
     }
 
     public Result<List<Asset>> request(QuerySpec input) {
 
         var requestBuilder = getAssetsRequestBuilder(input);
 
-        return this.edcApiHttpClient
-                .send(requestBuilder)
-                .map(JsonLdUtil::expand)
-                .map(this::getAssets);
+        return context.httpClient().send(requestBuilder).map(JsonLdUtil::expand).map(this::getAssets);
     }
 
     public CompletableFuture<Result<List<Asset>>> requestAsync(QuerySpec input) {
         var requestBuilder = getAssetsRequestBuilder(input);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
                 .map(this::getAssets));
     }
 

--- a/src/main/java/io/thinkit/edc/client/connector/services/Catalogs.java
+++ b/src/main/java/io/thinkit/edc/client/connector/services/Catalogs.java
@@ -3,36 +3,32 @@ package io.thinkit.edc.client.connector.services;
 import static io.thinkit.edc.client.connector.utils.JsonLdUtil.*;
 import static java.net.http.HttpRequest.BodyPublishers.ofString;
 
+import io.thinkit.edc.client.connector.EdcClientContext;
 import io.thinkit.edc.client.connector.model.*;
+import io.thinkit.edc.client.connector.resource.management.ManagementResource;
 import io.thinkit.edc.client.connector.utils.JsonLdUtil;
 import jakarta.json.JsonArray;
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.UnaryOperator;
 
-public class Catalogs {
+public class Catalogs extends ManagementResource {
     private final String url;
-    private final EdcApiHttpClient edcApiHttpClient;
 
-    public Catalogs(String url, HttpClient httpClient, UnaryOperator<HttpRequest.Builder> interceptor) {
-        edcApiHttpClient = new EdcApiHttpClient(httpClient, interceptor);
-        this.url = "%s/v3/catalog".formatted(url);
+    public Catalogs(EdcClientContext context) {
+        super(context);
+        url = "%s/v3/catalog".formatted(managementUrl);
     }
 
     public Result<Catalog> request(CatalogRequest input) {
         var requestBuilder = getCatalogRequestBuilder(input);
 
-        return this.edcApiHttpClient
-                .send(requestBuilder)
-                .map(JsonLdUtil::expand)
-                .map(this::getCatalog);
+        return context.httpClient().send(requestBuilder).map(JsonLdUtil::expand).map(this::getCatalog);
     }
 
     public CompletableFuture<Result<Catalog>> requestAsync(CatalogRequest input) {
         var requestBuilder = getCatalogRequestBuilder(input);
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
                 .map(this::getCatalog));
     }
 
@@ -40,17 +36,14 @@ public class Catalogs {
 
         var requestBuilder = requestDatasetRequestBuilder(input);
 
-        return this.edcApiHttpClient
-                .send(requestBuilder)
-                .map(JsonLdUtil::expand)
-                .map(this::getDataset);
+        return context.httpClient().send(requestBuilder).map(JsonLdUtil::expand).map(this::getDataset);
     }
 
     public CompletableFuture<Result<Dataset>> requestDatasetAsync(DatasetRequest input) {
 
         var requestBuilder = requestDatasetRequestBuilder(input);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
                 .map(this::getDataset));
     }
 

--- a/src/main/java/io/thinkit/edc/client/connector/services/ContractAgreements.java
+++ b/src/main/java/io/thinkit/edc/client/connector/services/ContractAgreements.java
@@ -1,69 +1,62 @@
 package io.thinkit.edc.client.connector.services;
 
-import static io.thinkit.edc.client.connector.utils.JsonLdUtil.*;
+import static io.thinkit.edc.client.connector.utils.JsonLdUtil.compact;
 import static java.net.http.HttpRequest.BodyPublishers.ofString;
 
-import io.thinkit.edc.client.connector.model.*;
+import io.thinkit.edc.client.connector.EdcClientContext;
+import io.thinkit.edc.client.connector.model.ContractAgreement;
+import io.thinkit.edc.client.connector.model.ContractNegotiation;
+import io.thinkit.edc.client.connector.model.QuerySpec;
+import io.thinkit.edc.client.connector.model.Result;
+import io.thinkit.edc.client.connector.resource.management.ManagementResource;
 import io.thinkit.edc.client.connector.utils.JsonLdUtil;
 import jakarta.json.JsonArray;
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.UnaryOperator;
 
-public class ContractAgreements {
+public class ContractAgreements extends ManagementResource {
     private final String url;
-    private final EdcApiHttpClient edcApiHttpClient;
 
-    public ContractAgreements(String url, HttpClient httpClient, UnaryOperator<HttpRequest.Builder> interceptor) {
-        edcApiHttpClient = new EdcApiHttpClient(httpClient, interceptor);
-        this.url = "%s/v3/contractagreements".formatted(url);
+    public ContractAgreements(EdcClientContext context) {
+        super(context);
+        url = "%s/v3/contractagreements".formatted(managementUrl);
     }
 
     public Result<ContractAgreement> get(String id) {
         var requestBuilder = getContractAgreementRequestBuilder(id);
 
-        return this.edcApiHttpClient
-                .send(requestBuilder)
-                .map(JsonLdUtil::expand)
-                .map(this::getContractAgreement);
+        return context.httpClient().send(requestBuilder).map(JsonLdUtil::expand).map(this::getContractAgreement);
     }
 
     public CompletableFuture<Result<ContractAgreement>> getAsync(String id) {
         var requestBuilder = getContractAgreementRequestBuilder(id);
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
                 .map(this::getContractAgreement));
     }
 
     public Result<ContractNegotiation> getNegotiation(String id) {
         var requestBuilder = getContractNegotiationRequestBuilder(id);
 
-        return this.edcApiHttpClient
-                .send(requestBuilder)
-                .map(JsonLdUtil::expand)
-                .map(this::getContractNegotiation);
+        return context.httpClient().send(requestBuilder).map(JsonLdUtil::expand).map(this::getContractNegotiation);
     }
 
     public CompletableFuture<Result<ContractNegotiation>> getNegotiationAsync(String id) {
         var requestBuilder = getContractNegotiationRequestBuilder(id);
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
                 .map(this::getContractNegotiation));
     }
 
     public Result<List<ContractAgreement>> request(QuerySpec input) {
         var requestBuilder = ContractAgreementsRequestBuilder(input);
-        return this.edcApiHttpClient
-                .send(requestBuilder)
-                .map(JsonLdUtil::expand)
-                .map(this::getContractAgreements);
+        return context.httpClient().send(requestBuilder).map(JsonLdUtil::expand).map(this::getContractAgreements);
     }
 
     public CompletableFuture<Result<List<ContractAgreement>>> requestAsync(QuerySpec input) {
         var requestBuilder = ContractAgreementsRequestBuilder(input);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
                 .map(this::getContractAgreements));
     }
 

--- a/src/main/java/io/thinkit/edc/client/connector/services/ContractDefinitions.java
+++ b/src/main/java/io/thinkit/edc/client/connector/services/ContractDefinitions.java
@@ -1,40 +1,38 @@
 package io.thinkit.edc.client.connector.services;
 
 import static io.thinkit.edc.client.connector.utils.Constants.ID;
-import static io.thinkit.edc.client.connector.utils.JsonLdUtil.*;
+import static io.thinkit.edc.client.connector.utils.JsonLdUtil.compact;
 import static java.net.http.HttpRequest.BodyPublishers.ofString;
 
-import io.thinkit.edc.client.connector.model.*;
+import io.thinkit.edc.client.connector.EdcClientContext;
+import io.thinkit.edc.client.connector.model.ContractDefinition;
+import io.thinkit.edc.client.connector.model.QuerySpec;
+import io.thinkit.edc.client.connector.model.Result;
+import io.thinkit.edc.client.connector.resource.management.ManagementResource;
 import io.thinkit.edc.client.connector.utils.JsonLdUtil;
 import jakarta.json.JsonArray;
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.UnaryOperator;
 
-public class ContractDefinitions {
+public class ContractDefinitions extends ManagementResource {
     private final String url;
-    private final EdcApiHttpClient edcApiHttpClient;
 
-    public ContractDefinitions(String url, HttpClient httpClient, UnaryOperator<HttpRequest.Builder> interceptor) {
-        edcApiHttpClient = new EdcApiHttpClient(httpClient, interceptor);
-        this.url = "%s/v3/contractdefinitions".formatted(url);
+    public ContractDefinitions(EdcClientContext context) {
+        super(context);
+        url = "%s/v3/contractdefinitions".formatted(managementUrl);
     }
 
     public Result<ContractDefinition> get(String id) {
         var requestBuilder = getRequestBuilder(id);
-        return this.edcApiHttpClient
-                .send(requestBuilder)
-                .map(JsonLdUtil::expand)
-                .map(this::getContractDefinition);
+        return context.httpClient().send(requestBuilder).map(JsonLdUtil::expand).map(this::getContractDefinition);
     }
 
     public CompletableFuture<Result<ContractDefinition>> getAsync(String id) {
         var requestBuilder = getRequestBuilder(id);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
                 .map(this::getContractDefinition));
     }
 
@@ -42,45 +40,40 @@ public class ContractDefinitions {
 
         var requestBuilder = createRequestBuilder(input);
 
-        return this.edcApiHttpClient
-                .send(requestBuilder)
-                .map(JsonLdUtil::expand)
-                .map(content -> content.getJsonObject(0).getString(ID));
+        return context.httpClient().send(requestBuilder).map(JsonLdUtil::expand).map(content -> content.getJsonObject(0)
+                .getString(ID));
     }
 
     public CompletableFuture<Result<String>> createAsync(ContractDefinition input) {
 
         var requestBuilder = createRequestBuilder(input);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
                 .map(content -> content.getJsonObject(0).getString(ID)));
     }
 
     public Result<String> delete(String id) {
         var requestBuilder = deleteRequestBuilder(id);
-        return this.edcApiHttpClient.send(requestBuilder).map(result -> id);
+        return context.httpClient().send(requestBuilder).map(result -> id);
     }
 
     public CompletableFuture<Result<String>> deleteAsync(String id) {
         var requestBuilder = deleteRequestBuilder(id);
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(content -> id));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(content -> id));
     }
 
     public Result<List<ContractDefinition>> request(QuerySpec input) {
 
         var requestBuilder = getContractDefinitionsRequestBuilder(input);
 
-        return this.edcApiHttpClient
-                .send(requestBuilder)
-                .map(JsonLdUtil::expand)
-                .map(this::getContractDefinitions);
+        return context.httpClient().send(requestBuilder).map(JsonLdUtil::expand).map(this::getContractDefinitions);
     }
 
     public CompletableFuture<Result<List<ContractDefinition>>> requestAsync(QuerySpec input) {
 
         var requestBuilder = getContractDefinitionsRequestBuilder(input);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
                 .map(this::getContractDefinitions));
     }
 
@@ -88,14 +81,14 @@ public class ContractDefinitions {
 
         var requestBuilder = updateRequestBuilder(input);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(result -> input.id());
+        return context.httpClient().send(requestBuilder).map(result -> input.id());
     }
 
     public CompletableFuture<Result<String>> updateAsync(ContractDefinition input) {
 
         var requestBuilder = updateRequestBuilder(input);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(content -> input.id()));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(content -> input.id()));
     }
 
     private HttpRequest.Builder getRequestBuilder(String id) {

--- a/src/main/java/io/thinkit/edc/client/connector/services/ContractNegotiations.java
+++ b/src/main/java/io/thinkit/edc/client/connector/services/ContractNegotiations.java
@@ -1,41 +1,42 @@
 package io.thinkit.edc.client.connector.services;
 
 import static io.thinkit.edc.client.connector.utils.Constants.ID;
-import static io.thinkit.edc.client.connector.utils.JsonLdUtil.*;
+import static io.thinkit.edc.client.connector.utils.JsonLdUtil.compact;
 import static java.net.http.HttpRequest.BodyPublishers.ofString;
 
-import io.thinkit.edc.client.connector.model.*;
+import io.thinkit.edc.client.connector.EdcClientContext;
+import io.thinkit.edc.client.connector.model.ContractAgreement;
+import io.thinkit.edc.client.connector.model.ContractNegotiation;
+import io.thinkit.edc.client.connector.model.ContractRequest;
+import io.thinkit.edc.client.connector.model.QuerySpec;
+import io.thinkit.edc.client.connector.model.Result;
+import io.thinkit.edc.client.connector.model.TerminateNegotiation;
+import io.thinkit.edc.client.connector.resource.management.ManagementResource;
 import io.thinkit.edc.client.connector.utils.JsonLdUtil;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.UnaryOperator;
 
-public class ContractNegotiations {
+public class ContractNegotiations extends ManagementResource {
     private final String url;
-    private final EdcApiHttpClient edcApiHttpClient;
 
-    public ContractNegotiations(String url, HttpClient httpClient, UnaryOperator<HttpRequest.Builder> interceptor) {
-        edcApiHttpClient = new EdcApiHttpClient(httpClient, interceptor);
-        this.url = "%s/v3/contractnegotiations".formatted(url);
+    public ContractNegotiations(EdcClientContext context) {
+        super(context);
+        url = "%s/v3/contractnegotiations".formatted(managementUrl);
     }
 
     public Result<ContractNegotiation> get(String id) {
         var requestBuilder = getRequestBuilder(id);
-        return this.edcApiHttpClient
-                .send(requestBuilder)
-                .map(JsonLdUtil::expand)
-                .map(this::getContractNegotiation);
+        return context.httpClient().send(requestBuilder).map(JsonLdUtil::expand).map(this::getContractNegotiation);
     }
 
     public CompletableFuture<Result<ContractNegotiation>> getAsync(String id) {
         var requestBuilder = getRequestBuilder(id);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
                 .map(this::getContractNegotiation));
     }
 
@@ -43,32 +44,27 @@ public class ContractNegotiations {
 
         var requestBuilder = createRequestBuilder(input);
 
-        return this.edcApiHttpClient
-                .send(requestBuilder)
-                .map(JsonLdUtil::expand)
-                .map(content -> content.getJsonObject(0).getString(ID));
+        return context.httpClient().send(requestBuilder).map(JsonLdUtil::expand).map(content -> content.getJsonObject(0)
+                .getString(ID));
     }
 
     public CompletableFuture<Result<String>> createAsync(ContractRequest input) {
 
         var requestBuilder = createRequestBuilder(input);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
                 .map(content -> content.getJsonObject(0).getString(ID)));
     }
 
     public Result<ContractAgreement> getAgreement(String id) {
         var requestBuilder = getContractAgreementRequestBuilder(id);
 
-        return this.edcApiHttpClient
-                .send(requestBuilder)
-                .map(JsonLdUtil::expand)
-                .map(this::getContractAgreement);
+        return context.httpClient().send(requestBuilder).map(JsonLdUtil::expand).map(this::getContractAgreement);
     }
 
     public CompletableFuture<Result<ContractAgreement>> getAgreementAsync(String id) {
         var requestBuilder = getContractAgreementRequestBuilder(id);
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
                 .map(this::getContractAgreement));
     }
 
@@ -76,38 +72,35 @@ public class ContractNegotiations {
 
         var requestBuilder = terminateRequestBuilder(input);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(result -> input.id());
+        return context.httpClient().send(requestBuilder).map(result -> input.id());
     }
 
     public CompletableFuture<Result<String>> terminateAsync(TerminateNegotiation input) {
 
         var requestBuilder = terminateRequestBuilder(input);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(content -> input.id()));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(content -> input.id()));
     }
 
     public Result<List<ContractNegotiation>> request(QuerySpec input) {
 
         var requestBuilder = getContractNegotiationsRequestBuilder(input);
 
-        return this.edcApiHttpClient
-                .send(requestBuilder)
-                .map(JsonLdUtil::expand)
-                .map(this::getContractNegotiations);
+        return context.httpClient().send(requestBuilder).map(JsonLdUtil::expand).map(this::getContractNegotiations);
     }
 
     public CompletableFuture<Result<List<ContractNegotiation>>> requestAsync(QuerySpec input) {
 
         var requestBuilder = getContractNegotiationsRequestBuilder(input);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
                 .map(this::getContractNegotiations));
     }
 
     public Result<String> getState(String id) {
         var requestBuilder = getStateRequestBuilder(id);
 
-        return this.edcApiHttpClient
+        return context.httpClient()
                 .send(requestBuilder)
                 .map(JsonLdUtil::ToJsonObject)
                 .map(this::getContractNegotiationState);
@@ -115,7 +108,7 @@ public class ContractNegotiations {
 
     public CompletableFuture<Result<String>> getStateAsync(String id) {
         var requestBuilder = getStateRequestBuilder(id);
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::ToJsonObject)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::ToJsonObject)
                 .map(this::getContractNegotiationState));
     }
 

--- a/src/main/java/io/thinkit/edc/client/connector/services/Dataplanes.java
+++ b/src/main/java/io/thinkit/edc/client/connector/services/Dataplanes.java
@@ -1,37 +1,33 @@
 package io.thinkit.edc.client.connector.services;
 
+import io.thinkit.edc.client.connector.EdcClientContext;
 import io.thinkit.edc.client.connector.model.DataPlaneInstance;
 import io.thinkit.edc.client.connector.model.Result;
+import io.thinkit.edc.client.connector.resource.management.ManagementResource;
 import io.thinkit.edc.client.connector.utils.JsonLdUtil;
 import jakarta.json.JsonArray;
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.UnaryOperator;
 
-public class Dataplanes {
+public class Dataplanes extends ManagementResource {
     private final String url;
-    private final EdcApiHttpClient edcApiHttpClient;
 
-    public Dataplanes(String url, HttpClient httpClient, UnaryOperator<HttpRequest.Builder> interceptor) {
-        edcApiHttpClient = new EdcApiHttpClient(httpClient, interceptor);
-        this.url = "%s/v3/dataplanes".formatted(url);
+    public Dataplanes(EdcClientContext context) {
+        super(context);
+        url = "%s/v3/dataplanes".formatted(managementUrl);
     }
 
     public Result<List<DataPlaneInstance>> get() {
         var requestBuilder = getRequestBuilder();
 
-        return this.edcApiHttpClient
-                .send(requestBuilder)
-                .map(JsonLdUtil::expand)
-                .map(this::getDataPlaneInstances);
+        return context.httpClient().send(requestBuilder).map(JsonLdUtil::expand).map(this::getDataPlaneInstances);
     }
 
     public CompletableFuture<Result<List<DataPlaneInstance>>> getAsync() {
         var requestBuilder = getRequestBuilder();
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
                 .map(this::getDataPlaneInstances));
     }
 

--- a/src/main/java/io/thinkit/edc/client/connector/services/EdrCache.java
+++ b/src/main/java/io/thinkit/edc/client/connector/services/EdrCache.java
@@ -3,66 +3,62 @@ package io.thinkit.edc.client.connector.services;
 import static io.thinkit.edc.client.connector.utils.JsonLdUtil.compact;
 import static java.net.http.HttpRequest.BodyPublishers.ofString;
 
-import io.thinkit.edc.client.connector.model.*;
+import io.thinkit.edc.client.connector.EdcClientContext;
+import io.thinkit.edc.client.connector.model.DataAddress;
+import io.thinkit.edc.client.connector.model.Edr;
+import io.thinkit.edc.client.connector.model.QuerySpec;
+import io.thinkit.edc.client.connector.model.Result;
+import io.thinkit.edc.client.connector.resource.management.ManagementResource;
 import io.thinkit.edc.client.connector.utils.JsonLdUtil;
 import jakarta.json.JsonArray;
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.UnaryOperator;
 
-public class EdrCache {
+public class EdrCache extends ManagementResource {
     private final String url;
-    private final EdcApiHttpClient edcApiHttpClient;
 
-    public EdrCache(String url, HttpClient httpClient, UnaryOperator<HttpRequest.Builder> interceptor) {
-        edcApiHttpClient = new EdcApiHttpClient(httpClient, interceptor);
-        this.url = "%s/v3/edrs".formatted(url);
+    public EdrCache(EdcClientContext context) {
+        super(context);
+        url = "%s/v3/edrs".formatted(managementUrl);
     }
 
     public Result<String> delete(String transferProcessId) {
         var requestBuilder = getDeleteRequestBuilder(transferProcessId);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(result -> transferProcessId);
+        return context.httpClient().send(requestBuilder).map(result -> transferProcessId);
     }
 
     public CompletableFuture<Result<String>> deleteAsync(String transferProcessId) {
         var requestBuilder = getDeleteRequestBuilder(transferProcessId);
 
-        return this.edcApiHttpClient
+        return context.httpClient()
                 .sendAsync(requestBuilder)
                 .thenApply(result -> result.map(content -> transferProcessId));
     }
 
     public Result<DataAddress> dataAddress(String transferProcessId) {
         var requestBuilder = getDataAddressRequestBuilder(transferProcessId);
-        return this.edcApiHttpClient
-                .send(requestBuilder)
-                .map(JsonLdUtil::expand)
-                .map(this::getDataAddress);
+        return context.httpClient().send(requestBuilder).map(JsonLdUtil::expand).map(this::getDataAddress);
     }
 
     public CompletableFuture<Result<DataAddress>> dataAddressAsync(String transferProcessId) {
         var requestBuilder = getDataAddressRequestBuilder(transferProcessId);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
                 .map(this::getDataAddress));
     }
 
     public Result<Edr> request(QuerySpec input) {
         var requestBuilder = getRequestBuilder(input);
 
-        return this.edcApiHttpClient
-                .send(requestBuilder)
-                .map(JsonLdUtil::expand)
-                .map(this::getEDR);
+        return context.httpClient().send(requestBuilder).map(JsonLdUtil::expand).map(this::getEDR);
     }
 
     public CompletableFuture<Result<Edr>> requestAsync(QuerySpec input) {
         var requestBuilder = getRequestBuilder(input);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
                 .map(this::getEDR));
     }
 

--- a/src/main/java/io/thinkit/edc/client/connector/services/PolicyDefinitions.java
+++ b/src/main/java/io/thinkit/edc/client/connector/services/PolicyDefinitions.java
@@ -1,41 +1,39 @@
 package io.thinkit.edc.client.connector.services;
 
 import static io.thinkit.edc.client.connector.utils.Constants.ID;
-import static io.thinkit.edc.client.connector.utils.JsonLdUtil.*;
+import static io.thinkit.edc.client.connector.utils.JsonLdUtil.compact;
 import static java.net.http.HttpRequest.BodyPublishers.ofString;
 
-import io.thinkit.edc.client.connector.model.*;
+import io.thinkit.edc.client.connector.EdcClientContext;
+import io.thinkit.edc.client.connector.model.PolicyDefinition;
+import io.thinkit.edc.client.connector.model.QuerySpec;
+import io.thinkit.edc.client.connector.model.Result;
+import io.thinkit.edc.client.connector.resource.management.ManagementResource;
 import io.thinkit.edc.client.connector.utils.JsonLdUtil;
 import jakarta.json.JsonArray;
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.UnaryOperator;
 
-public class PolicyDefinitions {
+public class PolicyDefinitions extends ManagementResource {
 
     private final String url;
-    private final EdcApiHttpClient edcApiHttpClient;
 
-    public PolicyDefinitions(String url, HttpClient httpClient, UnaryOperator<HttpRequest.Builder> interceptor) {
-        edcApiHttpClient = new EdcApiHttpClient(httpClient, interceptor);
-        this.url = "%s/v3/policydefinitions".formatted(url);
+    public PolicyDefinitions(EdcClientContext context) {
+        super(context);
+        url = "%s/v3/policydefinitions".formatted(managementUrl);
     }
 
     public Result<PolicyDefinition> get(String id) {
         var requestBuilder = getRequestBuilder(id);
 
-        return this.edcApiHttpClient
-                .send(requestBuilder)
-                .map(JsonLdUtil::expand)
-                .map(this::getPolicyDefinition);
+        return context.httpClient().send(requestBuilder).map(JsonLdUtil::expand).map(this::getPolicyDefinition);
     }
 
     public CompletableFuture<Result<PolicyDefinition>> getAsync(String id) {
         var requestBuilder = getRequestBuilder(id);
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
                 .map(this::getPolicyDefinition));
     }
 
@@ -43,17 +41,15 @@ public class PolicyDefinitions {
 
         var requestBuilder = createRequestBuilder(input);
 
-        return this.edcApiHttpClient
-                .send(requestBuilder)
-                .map(JsonLdUtil::expand)
-                .map(content -> content.getJsonObject(0).getString(ID));
+        return context.httpClient().send(requestBuilder).map(JsonLdUtil::expand).map(content -> content.getJsonObject(0)
+                .getString(ID));
     }
 
     public CompletableFuture<Result<String>> createAsync(PolicyDefinition input) {
 
         var requestBuilder = createRequestBuilder(input);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
                 .map(content -> content.getJsonObject(0).getString(ID)));
     }
 
@@ -61,43 +57,40 @@ public class PolicyDefinitions {
 
         var requestBuilder = updateRequestBuilder(input);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(result -> input.id());
+        return context.httpClient().send(requestBuilder).map(result -> input.id());
     }
 
     public CompletableFuture<Result<String>> updateAsync(PolicyDefinition input) {
 
         var requestBuilder = updateRequestBuilder(input);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(content -> input.id()));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(content -> input.id()));
     }
 
     public Result<String> delete(String id) {
         var requestBuilder = deleteRequestBuilder(id);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(result -> id);
+        return context.httpClient().send(requestBuilder).map(result -> id);
     }
 
     public CompletableFuture<Result<String>> deleteAsync(String id) {
         var requestBuilder = deleteRequestBuilder(id);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(content -> id));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(content -> id));
     }
 
     public Result<List<PolicyDefinition>> request(QuerySpec input) {
 
         var requestBuilder = getPolicyDefinitionsRequestBuilder(input);
 
-        return this.edcApiHttpClient
-                .send(requestBuilder)
-                .map(JsonLdUtil::expand)
-                .map(this::getPolicyDefinitions);
+        return context.httpClient().send(requestBuilder).map(JsonLdUtil::expand).map(this::getPolicyDefinitions);
     }
 
     public CompletableFuture<Result<List<PolicyDefinition>>> requestAsync(QuerySpec input) {
 
         var requestBuilder = getPolicyDefinitionsRequestBuilder(input);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
                 .map(this::getPolicyDefinitions));
     }
 

--- a/src/main/java/io/thinkit/edc/client/connector/services/Secrets.java
+++ b/src/main/java/io/thinkit/edc/client/connector/services/Secrets.java
@@ -4,79 +4,73 @@ import static io.thinkit.edc.client.connector.utils.Constants.ID;
 import static io.thinkit.edc.client.connector.utils.JsonLdUtil.compact;
 import static java.net.http.HttpRequest.BodyPublishers.ofString;
 
+import io.thinkit.edc.client.connector.EdcClientContext;
 import io.thinkit.edc.client.connector.model.Result;
 import io.thinkit.edc.client.connector.model.Secret;
+import io.thinkit.edc.client.connector.resource.management.ManagementResource;
 import io.thinkit.edc.client.connector.utils.JsonLdUtil;
 import jakarta.json.JsonArray;
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.UnaryOperator;
 
-public class Secrets {
+public class Secrets extends ManagementResource {
     private final String url;
-    private final EdcApiHttpClient edcApiHttpClient;
 
-    public Secrets(String url, HttpClient httpClient, UnaryOperator<HttpRequest.Builder> interceptor) {
-        edcApiHttpClient = new EdcApiHttpClient(httpClient, interceptor);
-        this.url = "%s/v3/secrets".formatted(url);
+    public Secrets(EdcClientContext context) {
+        super(context);
+        url = "%s/v3/secrets".formatted(managementUrl);
     }
 
     public Result<Secret> get(String id) {
         var requestBuilder = getRequestBuilder(id);
-        return this.edcApiHttpClient
-                .send(requestBuilder)
-                .map(JsonLdUtil::expand)
-                .map(this::getSecret);
+        return context.httpClient().send(requestBuilder).map(JsonLdUtil::expand).map(this::getSecret);
     }
 
     public CompletableFuture<Result<Secret>> getAsync(String id) {
         var requestBuilder = getRequestBuilder(id);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
                 .map(this::getSecret));
     }
 
     public Result<String> create(Secret input) {
         var requestBuilder = createRequestBuilder(input);
 
-        return this.edcApiHttpClient
-                .send(requestBuilder)
-                .map(JsonLdUtil::expand)
-                .map(content -> content.getJsonObject(0).getString(ID));
+        return context.httpClient().send(requestBuilder).map(JsonLdUtil::expand).map(content -> content.getJsonObject(0)
+                .getString(ID));
     }
 
     public CompletableFuture<Result<String>> createAsync(Secret input) {
         var requestBuilder = createRequestBuilder(input);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
                 .map(content -> content.getJsonObject(0).getString(ID)));
     }
 
     public Result<String> update(Secret input) {
         var requestBuilder = updateRequestBuilder(input);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(result -> input.id());
+        return context.httpClient().send(requestBuilder).map(result -> input.id());
     }
 
     public CompletableFuture<Result<String>> updateAsync(Secret input) {
 
         var requestBuilder = updateRequestBuilder(input);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(content -> input.id()));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(content -> input.id()));
     }
 
     public Result<String> delete(String id) {
         var requestBuilder = deleteRequestBuilder(id);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(result -> id);
+        return context.httpClient().send(requestBuilder).map(result -> id);
     }
 
     public CompletableFuture<Result<String>> deleteAsync(String id) {
         var requestBuilder = deleteRequestBuilder(id);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(content -> id));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(content -> id));
     }
 
     private HttpRequest.Builder getRequestBuilder(String id) {

--- a/src/main/java/io/thinkit/edc/client/connector/services/TransferProcesses.java
+++ b/src/main/java/io/thinkit/edc/client/connector/services/TransferProcesses.java
@@ -4,68 +4,59 @@ import static io.thinkit.edc.client.connector.utils.Constants.ID;
 import static io.thinkit.edc.client.connector.utils.JsonLdUtil.*;
 import static java.net.http.HttpRequest.BodyPublishers.ofString;
 
+import io.thinkit.edc.client.connector.EdcClientContext;
 import io.thinkit.edc.client.connector.model.*;
+import io.thinkit.edc.client.connector.resource.management.ManagementResource;
 import io.thinkit.edc.client.connector.utils.JsonLdUtil;
 import jakarta.json.JsonArray;
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.UnaryOperator;
 
-public class TransferProcesses {
+public class TransferProcesses extends ManagementResource {
     private final String url;
-    private final EdcApiHttpClient edcApiHttpClient;
 
-    public TransferProcesses(String url, HttpClient httpClient, UnaryOperator<HttpRequest.Builder> interceptor) {
-        edcApiHttpClient = new EdcApiHttpClient(httpClient, interceptor);
-        this.url = "%s/v3/transferprocesses".formatted(url);
+    public TransferProcesses(EdcClientContext context) {
+        super(context);
+        url = "%s/v3/transferprocesses".formatted(managementUrl);
     }
 
     public Result<TransferProcess> get(String id) {
         var requestBuilder = getContractAgreementRequestBuilder(id);
-        return this.edcApiHttpClient
-                .send(requestBuilder)
-                .map(JsonLdUtil::expand)
-                .map(this::getTransferProcess);
+        return context.httpClient().send(requestBuilder).map(JsonLdUtil::expand).map(this::getTransferProcess);
     }
 
     public CompletableFuture<Result<TransferProcess>> getAsync(String id) {
         var requestBuilder = getContractAgreementRequestBuilder(id);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
                 .map(this::getTransferProcess));
     }
 
     public Result<String> create(TransferRequest input) {
         var requestBuilder = createRequestBuilder(input);
 
-        return this.edcApiHttpClient
-                .send(requestBuilder)
-                .map(JsonLdUtil::expand)
-                .map(content -> content.getJsonObject(0).getString(ID));
+        return context.httpClient().send(requestBuilder).map(JsonLdUtil::expand).map(content -> content.getJsonObject(0)
+                .getString(ID));
     }
 
     public CompletableFuture<Result<String>> createAsync(TransferRequest input) {
 
         var requestBuilder = createRequestBuilder(input);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
                 .map(content -> content.getJsonObject(0).getString(ID)));
     }
 
     public Result<TransferState> getState(String id) {
         var requestBuilder = getStateRequestBuilder(id);
 
-        return this.edcApiHttpClient
-                .send(requestBuilder)
-                .map(JsonLdUtil::expand)
-                .map(this::getTransferState);
+        return context.httpClient().send(requestBuilder).map(JsonLdUtil::expand).map(this::getTransferState);
     }
 
     public CompletableFuture<Result<TransferState>> getStateAsync(String id) {
         var requestBuilder = getStateRequestBuilder(id);
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::expand)
                 .map(this::getTransferState));
     }
 
@@ -73,25 +64,25 @@ public class TransferProcesses {
 
         var requestBuilder = terminateRequestBuilder(input);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(result -> input.id());
+        return context.httpClient().send(requestBuilder).map(result -> input.id());
     }
 
     public CompletableFuture<Result<String>> terminateAsync(TerminateTransfer input) {
 
         var requestBuilder = terminateRequestBuilder(input);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(content -> input.id()));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(content -> input.id()));
     }
 
     public Result<String> deprovision(String id) {
         var requestBuilder = deprovisionRequestBuilder(id);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(result -> id);
+        return context.httpClient().send(requestBuilder).map(result -> id);
     }
 
     public CompletableFuture<Result<String>> deprovisionAsync(String id) {
         var requestBuilder = deprovisionRequestBuilder(id);
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(content -> id));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(content -> id));
     }
 
     private HttpRequest.Builder getContractAgreementRequestBuilder(String id) {

--- a/src/test/java/io/thinkit/edc/client/connector/EdcConnectorClientTest.java
+++ b/src/test/java/io/thinkit/edc/client/connector/EdcConnectorClientTest.java
@@ -1,9 +1,10 @@
 package io.thinkit.edc.client.connector;
 
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.thinkit.edc.client.connector.resource.EdcResource;
+import org.junit.jupiter.api.Test;
 
 public class EdcConnectorClientTest {
 


### PR DESCRIPTION
### What

Make the "management" resources pass through the new spi:
- they now extend `EdcResource`
- they are registered as resource creators in the client

### Notes:
other kind of resources will be managed separately

Part of #174