### PR TITLE
refactor: make all the core resources to use the same format

### DIFF
--- a/src/main/java/io/thinkit/edc/client/connector/EdcConnectorClient.java
+++ b/src/main/java/io/thinkit/edc/client/connector/EdcConnectorClient.java
@@ -1,5 +1,6 @@
 package io.thinkit.edc.client.connector;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.thinkit.edc.client.connector.resource.EdcResource;
 import io.thinkit.edc.client.connector.services.ApplicationObservability;
@@ -77,11 +78,7 @@ public class EdcConnectorClient {
     }
 
     public ApplicationObservability applicationObservability() {
-        if (observabilityUrl == null) {
-            throw new IllegalArgumentException(
-                    "Cannot instantiate ApplicationObservability client without the observability url");
-        }
-        return new ApplicationObservability(observabilityUrl, httpClient, interceptor);
+        return resource(ApplicationObservability.class);
     }
 
     public Catalogs catalogs() {
@@ -97,39 +94,23 @@ public class EdcConnectorClient {
     }
 
     public CatalogCache catalogCache() {
-        if (catalogCacheUrl == null) {
-            throw new IllegalArgumentException("Cannot instantiate CatalogCache client without the catalog cache url");
-        }
-        return new CatalogCache(catalogCacheUrl, httpClient, interceptor);
+        return resource(CatalogCache.class);
     }
 
     public VerifiableCredentials verifiableCredentials() {
-        if (identityUrl == null) {
-            throw new IllegalArgumentException(
-                    "Cannot instantiate verifiableCredentials client without the identity url");
-        }
-        return new VerifiableCredentials(identityUrl, httpClient, interceptor, objectMapper);
+        return resource(VerifiableCredentials.class);
     }
 
     public Did did() {
-        if (identityUrl == null) {
-            throw new IllegalArgumentException("Cannot instantiate Did client without the identity url");
-        }
-        return new Did(identityUrl, httpClient, interceptor, objectMapper);
+        return resource(Did.class);
     }
 
     public KeyPairs keyPairs() {
-        if (identityUrl == null) {
-            throw new IllegalArgumentException("Cannot instantiate Did client without the identity url");
-        }
-        return new KeyPairs(identityUrl, httpClient, interceptor, objectMapper);
+        return resource(KeyPairs.class);
     }
 
     public Participants participants() {
-        if (identityUrl == null) {
-            throw new IllegalArgumentException("Cannot instantiate Did client without the identity url");
-        }
-        return new Participants(identityUrl, httpClient, interceptor, objectMapper);
+        return resource(Participants.class);
     }
 
     public <T extends EdcResource> T resource(Class<T> resourceClass) {
@@ -155,6 +136,10 @@ public class EdcConnectorClient {
     public static class Builder {
 
         private final EdcConnectorClient client = new EdcConnectorClient();
+
+        public Builder() {
+            client.objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        }
 
         public Builder managementUrl(String managementUrl) {
             client.managementUrl = managementUrl;
@@ -210,6 +195,12 @@ public class EdcConnectorClient {
             with(Catalogs.class, Catalogs::new);
             with(EdrCache.class, EdrCache::new);
             with(Secrets.class, Secrets::new);
+            with(ApplicationObservability.class, ApplicationObservability::new);
+            with(CatalogCache.class, CatalogCache::new);
+            with(VerifiableCredentials.class, VerifiableCredentials::new);
+            with(Did.class, Did::new);
+            with(KeyPairs.class, KeyPairs::new);
+            with(Participants.class, Participants::new);
             return client;
         }
     }

--- a/src/main/java/io/thinkit/edc/client/connector/resource/catalog/CatalogCacheResource.java
+++ b/src/main/java/io/thinkit/edc/client/connector/resource/catalog/CatalogCacheResource.java
@@ -1,0 +1,18 @@
+package io.thinkit.edc.client.connector.resource.catalog;
+
+import io.thinkit.edc.client.connector.EdcClientContext;
+import io.thinkit.edc.client.connector.resource.EdcResource;
+
+public class CatalogCacheResource extends EdcResource {
+
+    protected final String catalogCacheUrl;
+
+    protected CatalogCacheResource(EdcClientContext context) {
+        super(context);
+        catalogCacheUrl = context.urls().catalogCache();
+        if (catalogCacheUrl == null) {
+            throw new IllegalArgumentException("Cannot instantiate %s client without the catalog url"
+                    .formatted(getClass().getSimpleName()));
+        }
+    }
+}

--- a/src/main/java/io/thinkit/edc/client/connector/resource/identity/IdentityResource.java
+++ b/src/main/java/io/thinkit/edc/client/connector/resource/identity/IdentityResource.java
@@ -1,0 +1,18 @@
+package io.thinkit.edc.client.connector.resource.identity;
+
+import io.thinkit.edc.client.connector.EdcClientContext;
+import io.thinkit.edc.client.connector.resource.EdcResource;
+
+public class IdentityResource extends EdcResource {
+
+    protected final String identityUrl;
+
+    protected IdentityResource(EdcClientContext context) {
+        super(context);
+        identityUrl = context.urls().identityUrl();
+        if (identityUrl == null) {
+            throw new IllegalArgumentException("Cannot instantiate %s client without the identity url"
+                    .formatted(getClass().getSimpleName()));
+        }
+    }
+}

--- a/src/main/java/io/thinkit/edc/client/connector/resource/observability/ObservabilityResource.java
+++ b/src/main/java/io/thinkit/edc/client/connector/resource/observability/ObservabilityResource.java
@@ -1,0 +1,18 @@
+package io.thinkit.edc.client.connector.resource.observability;
+
+import io.thinkit.edc.client.connector.EdcClientContext;
+import io.thinkit.edc.client.connector.resource.EdcResource;
+
+public class ObservabilityResource extends EdcResource {
+
+    protected final String observabilityUrl;
+
+    protected ObservabilityResource(EdcClientContext context) {
+        super(context);
+        observabilityUrl = context.urls().observability();
+        if (observabilityUrl == null) {
+            throw new IllegalArgumentException("Cannot instantiate %s client without the observability url"
+                    .formatted(getClass().getSimpleName()));
+        }
+    }
+}

--- a/src/main/java/io/thinkit/edc/client/connector/services/ApplicationObservability.java
+++ b/src/main/java/io/thinkit/edc/client/connector/services/ApplicationObservability.java
@@ -1,28 +1,27 @@
 package io.thinkit.edc.client.connector.services;
 
+import io.thinkit.edc.client.connector.EdcClientContext;
 import io.thinkit.edc.client.connector.model.HealthStatus;
 import io.thinkit.edc.client.connector.model.Result;
+import io.thinkit.edc.client.connector.resource.observability.ObservabilityResource;
 import io.thinkit.edc.client.connector.utils.JsonLdUtil;
 import jakarta.json.JsonObject;
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.UnaryOperator;
 
-public class ApplicationObservability {
+public class ApplicationObservability extends ObservabilityResource {
     private final String url;
-    private final EdcApiHttpClient edcApiHttpClient;
 
-    public ApplicationObservability(String url, HttpClient httpClient, UnaryOperator<HttpRequest.Builder> interceptor) {
-        edcApiHttpClient = new EdcApiHttpClient(httpClient, interceptor);
-        this.url = url;
+    public ApplicationObservability(EdcClientContext context) {
+        super(context);
+        url = "%s/check".formatted(observabilityUrl);
     }
 
     public Result<HealthStatus> checkHealth() {
         var requestBuilder = checkHealthRequestBuilder();
 
-        return this.edcApiHttpClient
+        return context.httpClient()
                 .send(requestBuilder)
                 .map(JsonLdUtil::ToJsonObject)
                 .map(this::getHealthStatus);
@@ -31,14 +30,14 @@ public class ApplicationObservability {
     public CompletableFuture<Result<HealthStatus>> checkHealthAsync() {
         var requestBuilder = checkHealthRequestBuilder();
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::ToJsonObject)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::ToJsonObject)
                 .map(this::getHealthStatus));
     }
 
     public Result<HealthStatus> checkReadiness() {
         var requestBuilder = checkReadinessRequestBuilder();
 
-        return this.edcApiHttpClient
+        return context.httpClient()
                 .send(requestBuilder)
                 .map(JsonLdUtil::ToJsonObject)
                 .map(this::getHealthStatus);
@@ -47,14 +46,14 @@ public class ApplicationObservability {
     public CompletableFuture<Result<HealthStatus>> checkReadinessAsync() {
         var requestBuilder = checkReadinessRequestBuilder();
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::ToJsonObject)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::ToJsonObject)
                 .map(this::getHealthStatus));
     }
 
     public Result<HealthStatus> checkStartup() {
         var requestBuilder = checkStartupRequestBuilder();
 
-        return this.edcApiHttpClient
+        return context.httpClient()
                 .send(requestBuilder)
                 .map(JsonLdUtil::ToJsonObject)
                 .map(this::getHealthStatus);
@@ -63,13 +62,13 @@ public class ApplicationObservability {
     public CompletableFuture<Result<HealthStatus>> checkStartupAsync() {
         var requestBuilder = checkStartupRequestBuilder();
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::ToJsonObject)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::ToJsonObject)
                 .map(this::getHealthStatus));
     }
 
     public Result<HealthStatus> checkLiveness() {
         var requestBuilder = checkLivenessRequestBuilder();
-        return this.edcApiHttpClient
+        return context.httpClient()
                 .send(requestBuilder)
                 .map(JsonLdUtil::ToJsonObject)
                 .map(this::getHealthStatus);
@@ -77,31 +76,31 @@ public class ApplicationObservability {
 
     public CompletableFuture<Result<HealthStatus>> checkLivenessAsync() {
         var requestBuilder = checkLivenessRequestBuilder();
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::ToJsonObject)
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(JsonLdUtil::ToJsonObject)
                 .map(this::getHealthStatus));
     }
 
     private HttpRequest.Builder checkHealthRequestBuilder() {
         return HttpRequest.newBuilder()
-                .uri(URI.create("%s/check/health".formatted(this.url)))
+                .uri(URI.create("%s/health".formatted(this.url)))
                 .GET();
     }
 
     private HttpRequest.Builder checkReadinessRequestBuilder() {
         return HttpRequest.newBuilder()
-                .uri(URI.create("%s/check/readiness".formatted(this.url)))
+                .uri(URI.create("%s/readiness".formatted(this.url)))
                 .GET();
     }
 
     private HttpRequest.Builder checkStartupRequestBuilder() {
         return HttpRequest.newBuilder()
-                .uri(URI.create("%s/check/startup".formatted(this.url)))
+                .uri(URI.create("%s/startup".formatted(this.url)))
                 .GET();
     }
 
     private HttpRequest.Builder checkLivenessRequestBuilder() {
         return HttpRequest.newBuilder()
-                .uri(URI.create("%s/check/liveness".formatted(this.url)))
+                .uri(URI.create("%s/liveness".formatted(this.url)))
                 .GET();
     }
 

--- a/src/main/java/io/thinkit/edc/client/connector/services/CatalogCache.java
+++ b/src/main/java/io/thinkit/edc/client/connector/services/CatalogCache.java
@@ -3,38 +3,37 @@ package io.thinkit.edc.client.connector.services;
 import static io.thinkit.edc.client.connector.utils.JsonLdUtil.compact;
 import static java.net.http.HttpRequest.BodyPublishers.ofString;
 
+import io.thinkit.edc.client.connector.EdcClientContext;
 import io.thinkit.edc.client.connector.model.Catalog;
 import io.thinkit.edc.client.connector.model.QuerySpec;
 import io.thinkit.edc.client.connector.model.Result;
+import io.thinkit.edc.client.connector.resource.catalog.CatalogCacheResource;
 import io.thinkit.edc.client.connector.utils.JsonLdUtil;
 import jakarta.json.JsonValue;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.UnaryOperator;
 
-public class CatalogCache {
-    private final EdcApiHttpClient edcApiHttpClient;
+public class CatalogCache extends CatalogCacheResource {
     private final String url;
 
-    public CatalogCache(String url, HttpClient httpClient, UnaryOperator<HttpRequest.Builder> interceptor) {
-        edcApiHttpClient = new EdcApiHttpClient(httpClient, interceptor);
-        this.url = "%s/v1alpha/catalog".formatted(url);
+    public CatalogCache(EdcClientContext context) {
+        super(context);
+        url = "%s/v1alpha/catalog".formatted(catalogCacheUrl);
     }
 
     public Result<List<Catalog>> query(QuerySpec query) {
         var requestBuilder = queryCatalogsRequestBuilder(query);
 
-        return handleOutput(edcApiHttpClient.send(requestBuilder));
+        return handleOutput(context.httpClient().send(requestBuilder));
     }
 
     public CompletableFuture<Result<List<Catalog>>> queryAsync(QuerySpec query) {
         var requestBuilder = queryCatalogsRequestBuilder(query);
 
-        return edcApiHttpClient.sendAsync(requestBuilder).thenApply(this::handleOutput);
+        return context.httpClient().sendAsync(requestBuilder).thenApply(this::handleOutput);
     }
 
     private Result<List<Catalog>> handleOutput(Result<InputStream> output) {

--- a/src/main/java/io/thinkit/edc/client/connector/services/Did.java
+++ b/src/main/java/io/thinkit/edc/client/connector/services/Did.java
@@ -2,143 +2,127 @@ package io.thinkit.edc.client.connector.services;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.thinkit.edc.client.connector.model.*;
+import io.thinkit.edc.client.connector.EdcClientContext;
+import io.thinkit.edc.client.connector.model.DidDocument;
+import io.thinkit.edc.client.connector.model.DidRequestPayload;
+import io.thinkit.edc.client.connector.model.QuerySpecInput;
+import io.thinkit.edc.client.connector.model.Result;
+import io.thinkit.edc.client.connector.model.ServiceInput;
+import io.thinkit.edc.client.connector.resource.identity.IdentityResource;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.UnaryOperator;
 
-public class Did {
+public class Did extends IdentityResource {
+
     private final String url;
-    private final EdcApiHttpClient edcApiHttpClient;
 
-    private final ObjectMapper objectMapper;
-
-    public Did(
-            String url,
-            HttpClient httpClient,
-            UnaryOperator<HttpRequest.Builder> interceptor,
-            ObjectMapper objectMapper) {
-        edcApiHttpClient = new EdcApiHttpClient(httpClient, interceptor);
-        this.objectMapper = objectMapper;
-        this.url = "%s/v1alpha".formatted(url);
+    public Did(EdcClientContext context) {
+        super(context);
+        url = "%s/v1alpha".formatted(identityUrl);
     }
 
     public Result<List<DidDocument>> get(int offset, int limit) {
         var requestBuilder = getRequestBuilder(offset, limit);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(this::getDidDocuments);
+        return context.httpClient().send(requestBuilder).map(this::getDidDocuments);
     }
 
     public CompletableFuture<Result<List<DidDocument>>> getAsync(int offset, int limit) {
         var requestBuilder = getRequestBuilder(offset, limit);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(this::getDidDocuments));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(this::getDidDocuments));
     }
 
     public Result<String> publish(DidRequestPayload input, String participantId) {
         var requestBuilder = publishRequestBuilder(input, participantId);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(result -> participantId);
+        return context.httpClient().send(requestBuilder).map(result -> participantId);
     }
 
     public CompletableFuture<Result<String>> publishAsync(DidRequestPayload input, String participantId) {
         var requestBuilder = publishRequestBuilder(input, participantId);
 
-        return this.edcApiHttpClient
-                .sendAsync(requestBuilder)
-                .thenApply(result -> result.map(content -> participantId));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(content -> participantId));
     }
 
     public Result<String> unpublish(DidRequestPayload input, String participantId) {
         var requestBuilder = unpublishRequestBuilder(input, participantId);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(result -> participantId);
+        return context.httpClient().send(requestBuilder).map(result -> participantId);
     }
 
     public CompletableFuture<Result<String>> unpublishAsync(DidRequestPayload input, String participantId) {
         var requestBuilder = unpublishRequestBuilder(input, participantId);
 
-        return this.edcApiHttpClient
-                .sendAsync(requestBuilder)
-                .thenApply(result -> result.map(content -> participantId));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(content -> participantId));
     }
 
     public Result<String> getState(DidRequestPayload input, String participantId) {
         var requestBuilder = getStateRequestBuilder(input, participantId);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(result -> participantId);
+        return context.httpClient().send(requestBuilder).map(result -> participantId);
     }
 
     public CompletableFuture<Result<String>> getStateAsync(DidRequestPayload input, String participantId) {
         var requestBuilder = getStateRequestBuilder(input, participantId);
 
-        return this.edcApiHttpClient
-                .sendAsync(requestBuilder)
-                .thenApply(result -> result.map(content -> participantId));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(content -> participantId));
     }
 
     public Result<String> addServiceEndpoint(
             ServiceInput input, String participantId, String did, Boolean autoPublish) {
         var requestBuilder = addServiceEndpointRequestBuilder(input, participantId, did, autoPublish);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(result -> participantId);
+        return context.httpClient().send(requestBuilder).map(result -> participantId);
     }
 
     public CompletableFuture<Result<String>> addServiceEndpointAsync(
             ServiceInput input, String participantId, String did, Boolean autoPublish) {
         var requestBuilder = addServiceEndpointRequestBuilder(input, participantId, did, autoPublish);
 
-        return this.edcApiHttpClient
-                .sendAsync(requestBuilder)
-                .thenApply(result -> result.map(content -> participantId));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(content -> participantId));
     }
 
     public Result<List<DidDocument>> query(QuerySpecInput input, String participantId) {
         var requestBuilder = queryRequestBuilder(input, participantId);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(this::getDidDocuments);
+        return context.httpClient().send(requestBuilder).map(this::getDidDocuments);
     }
 
     public CompletableFuture<Result<List<DidDocument>>> queryAsync(QuerySpecInput input, String participantId) {
         var requestBuilder = queryRequestBuilder(input, participantId);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(this::getDidDocuments));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(this::getDidDocuments));
     }
 
     public Result<String> delete(String participantId, String did, String serviceId, Boolean autoPublish) {
         var requestBuilder = deleteRequestBuilder(participantId, did, serviceId, autoPublish);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(result -> participantId);
+        return context.httpClient().send(requestBuilder).map(result -> participantId);
     }
 
     public CompletableFuture<Result<String>> deleteAsync(
             String participantId, String did, String serviceId, Boolean autoPublish) {
         var requestBuilder = deleteRequestBuilder(participantId, did, serviceId, autoPublish);
 
-        return this.edcApiHttpClient
-                .sendAsync(requestBuilder)
-                .thenApply(result -> result.map(content -> participantId));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(content -> participantId));
     }
 
     public Result<String> update(ServiceInput input, String participantId, String did, Boolean autoPublish) {
         var requestBuilder = updateRequestBuilder(input, participantId, did, autoPublish);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(result -> participantId);
+        return context.httpClient().send(requestBuilder).map(result -> participantId);
     }
 
     public CompletableFuture<Result<String>> updateAsync(
             ServiceInput input, String participantId, String did, Boolean autoPublish) {
         var requestBuilder = updateRequestBuilder(input, participantId, did, autoPublish);
 
-        return this.edcApiHttpClient
-                .sendAsync(requestBuilder)
-                .thenApply(result -> result.map(content -> participantId));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(content -> participantId));
     }
 
     private HttpRequest.Builder getRequestBuilder(int offset, int limit) {
@@ -148,9 +132,9 @@ public class Did {
     }
 
     private HttpRequest.Builder queryRequestBuilder(QuerySpecInput input, String participantId) {
-        String requestBody = null;
+        String requestBody;
         try {
-            requestBody = objectMapper.writeValueAsString(input);
+            requestBody = context.objectMapper().writeValueAsString(input);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
@@ -170,9 +154,9 @@ public class Did {
 
     private HttpRequest.Builder updateRequestBuilder(
             ServiceInput input, String participantId, String did, Boolean autoPublish) {
-        String requestBody = null;
+        String requestBody;
         try {
-            requestBody = objectMapper.writeValueAsString(input);
+            requestBody = context.objectMapper().writeValueAsString(input);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
@@ -184,9 +168,9 @@ public class Did {
     }
 
     private HttpRequest.Builder publishRequestBuilder(DidRequestPayload input, String participantId) {
-        String requestBody = null;
+        String requestBody;
         try {
-            requestBody = objectMapper.writeValueAsString(input);
+            requestBody = context.objectMapper().writeValueAsString(input);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
@@ -197,9 +181,9 @@ public class Did {
     }
 
     private HttpRequest.Builder unpublishRequestBuilder(DidRequestPayload input, String participantId) {
-        String requestBody = null;
+        String requestBody;
         try {
-            requestBody = objectMapper.writeValueAsString(input);
+            requestBody = context.objectMapper().writeValueAsString(input);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
@@ -210,9 +194,9 @@ public class Did {
     }
 
     private HttpRequest.Builder getStateRequestBuilder(DidRequestPayload input, String participantId) {
-        String requestBody = null;
+        String requestBody;
         try {
-            requestBody = objectMapper.writeValueAsString(input);
+            requestBody = context.objectMapper().writeValueAsString(input);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
@@ -224,9 +208,9 @@ public class Did {
 
     private HttpRequest.Builder addServiceEndpointRequestBuilder(
             ServiceInput input, String participantId, String did, Boolean autoPublish) {
-        String requestBody = null;
+        String requestBody;
         try {
-            requestBody = objectMapper.writeValueAsString(input);
+            requestBody = context.objectMapper().writeValueAsString(input);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
@@ -239,7 +223,7 @@ public class Did {
 
     private List<DidDocument> getDidDocuments(InputStream body) {
         try {
-            return objectMapper.readValue(body, new TypeReference<List<DidDocument>>() {});
+            return context.objectMapper().readValue(body, new TypeReference<List<DidDocument>>() {});
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/io/thinkit/edc/client/connector/services/KeyPairs.java
+++ b/src/main/java/io/thinkit/edc/client/connector/services/KeyPairs.java
@@ -2,126 +2,109 @@ package io.thinkit.edc.client.connector.services;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.thinkit.edc.client.connector.model.*;
+import io.thinkit.edc.client.connector.EdcClientContext;
+import io.thinkit.edc.client.connector.model.KeyDescriptor;
+import io.thinkit.edc.client.connector.model.KeyPairResource;
+import io.thinkit.edc.client.connector.model.Result;
+import io.thinkit.edc.client.connector.resource.identity.IdentityResource;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.UnaryOperator;
 
-public class KeyPairs {
+public class KeyPairs extends IdentityResource {
     private final String url;
-    private final EdcApiHttpClient edcApiHttpClient;
 
-    private final ObjectMapper objectMapper;
-
-    public KeyPairs(
-            String url,
-            HttpClient httpClient,
-            UnaryOperator<HttpRequest.Builder> interceptor,
-            ObjectMapper objectMapper) {
-        edcApiHttpClient = new EdcApiHttpClient(httpClient, interceptor);
-        this.objectMapper = objectMapper;
-        this.url = "%s/v1alpha".formatted(url);
+    public KeyPairs(EdcClientContext context) {
+        super(context);
+        url = "%s/v1alpha".formatted(identityUrl);
     }
 
     public Result<List<KeyPairResource>> getAll(int offset, int limit) {
         var requestBuilder = getAllRequestBuilder(offset, limit);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(this::getKeyPairs);
+        return context.httpClient().send(requestBuilder).map(this::getKeyPairs);
     }
 
     public CompletableFuture<Result<List<KeyPairResource>>> getAllAsync(int offset, int limit) {
         var requestBuilder = getAllRequestBuilder(offset, limit);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(this::getKeyPairs));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(this::getKeyPairs));
     }
 
     public Result<List<KeyPairResource>> get(String participantId) {
         var requestBuilder = getRequestBuilder(participantId);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(this::getKeyPairs);
+        return context.httpClient().send(requestBuilder).map(this::getKeyPairs);
     }
 
     public CompletableFuture<Result<List<KeyPairResource>>> getAsync(String participantId) {
         var requestBuilder = getRequestBuilder(participantId);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(this::getKeyPairs));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(this::getKeyPairs));
     }
 
     public Result<String> add(KeyDescriptor input, String participantId, Boolean makeDefault) {
         var requestBuilder = addRequestBuilder(input, participantId, makeDefault);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(result -> participantId);
+        return context.httpClient().send(requestBuilder).map(result -> participantId);
     }
 
     public CompletableFuture<Result<String>> addAsync(KeyDescriptor input, String participantId, Boolean makeDefault) {
         var requestBuilder = addRequestBuilder(input, participantId, makeDefault);
 
-        return this.edcApiHttpClient
-                .sendAsync(requestBuilder)
-                .thenApply(result -> result.map(content -> participantId));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(content -> participantId));
     }
 
     public Result<KeyPairResource> getOne(String participantId, String keyPairId) {
         var requestBuilder = getOneRequestBuilder(participantId, keyPairId);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(this::getKeyPairResource);
+        return context.httpClient().send(requestBuilder).map(this::getKeyPairResource);
     }
 
     public CompletableFuture<Result<KeyPairResource>> getOneAsync(String participantId, String keyPairId) {
         var requestBuilder = getOneRequestBuilder(participantId, keyPairId);
 
-        return this.edcApiHttpClient
-                .sendAsync(requestBuilder)
-                .thenApply(result -> result.map(this::getKeyPairResource));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(this::getKeyPairResource));
     }
 
     public Result<String> activate(String participantId, String keyPairId) {
         var requestBuilder = activateRequestBuilder(participantId, keyPairId);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(result -> participantId);
+        return context.httpClient().send(requestBuilder).map(result -> participantId);
     }
 
     public CompletableFuture<Result<String>> activateAsync(String participantId, String keyPairId) {
         var requestBuilder = activateRequestBuilder(participantId, keyPairId);
 
-        return this.edcApiHttpClient
-                .sendAsync(requestBuilder)
-                .thenApply(result -> result.map(content -> participantId));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(content -> participantId));
     }
 
     public Result<String> revoke(String participantId, String keyPairId, KeyDescriptor input) {
         var requestBuilder = revokeRequestBuilder(participantId, keyPairId, input);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(result -> participantId);
+        return context.httpClient().send(requestBuilder).map(result -> participantId);
     }
 
     public CompletableFuture<Result<String>> revokeAsync(String participantId, String keyPairId, KeyDescriptor input) {
         var requestBuilder = revokeRequestBuilder(participantId, keyPairId, input);
 
-        return this.edcApiHttpClient
-                .sendAsync(requestBuilder)
-                .thenApply(result -> result.map(content -> participantId));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(content -> participantId));
     }
 
     public Result<String> rotate(String participantId, String keyPairId, KeyDescriptor input, int duration) {
         var requestBuilder = rotateRequestBuilder(participantId, keyPairId, input, duration);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(result -> participantId);
+        return context.httpClient().send(requestBuilder).map(result -> participantId);
     }
 
     public CompletableFuture<Result<String>> rotateAsync(
             String participantId, String keyPairId, KeyDescriptor input, int duration) {
         var requestBuilder = rotateRequestBuilder(participantId, keyPairId, input, duration);
 
-        return this.edcApiHttpClient
-                .sendAsync(requestBuilder)
-                .thenApply(result -> result.map(content -> participantId));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(content -> participantId));
     }
 
     private HttpRequest.Builder getAllRequestBuilder(int offset, int limit) {
@@ -143,9 +126,9 @@ public class KeyPairs {
     }
 
     private HttpRequest.Builder addRequestBuilder(KeyDescriptor input, String participantId, Boolean makeDefault) {
-        String requestBody = null;
+        String requestBody;
         try {
-            requestBody = objectMapper.writeValueAsString(input);
+            requestBody = context.objectMapper().writeValueAsString(input);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
@@ -166,9 +149,9 @@ public class KeyPairs {
     }
 
     private HttpRequest.Builder revokeRequestBuilder(String participantId, String keyPairId, KeyDescriptor input) {
-        String requestBody = null;
+        String requestBody;
         try {
-            requestBody = objectMapper.writeValueAsString(input);
+            requestBody = context.objectMapper().writeValueAsString(input);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
@@ -180,9 +163,9 @@ public class KeyPairs {
 
     private HttpRequest.Builder rotateRequestBuilder(
             String participantId, String keyPairId, KeyDescriptor input, int duration) {
-        String requestBody = null;
+        String requestBody;
         try {
-            requestBody = objectMapper.writeValueAsString(input);
+            requestBody = context.objectMapper().writeValueAsString(input);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
@@ -195,7 +178,7 @@ public class KeyPairs {
 
     private List<KeyPairResource> getKeyPairs(InputStream body) {
         try {
-            return objectMapper.readValue(body, new TypeReference<List<KeyPairResource>>() {});
+            return context.objectMapper().readValue(body, new TypeReference<List<KeyPairResource>>() {});
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -203,7 +186,7 @@ public class KeyPairs {
 
     private KeyPairResource getKeyPairResource(InputStream body) {
         try {
-            return objectMapper.readValue(body, KeyPairResource.class);
+            return context.objectMapper().readValue(body, KeyPairResource.class);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/io/thinkit/edc/client/connector/services/Participants.java
+++ b/src/main/java/io/thinkit/edc/client/connector/services/Participants.java
@@ -2,55 +2,49 @@ package io.thinkit.edc.client.connector.services;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.thinkit.edc.client.connector.model.*;
+import io.thinkit.edc.client.connector.EdcClientContext;
+import io.thinkit.edc.client.connector.model.ParticipantContext;
+import io.thinkit.edc.client.connector.model.ParticipantManifest;
+import io.thinkit.edc.client.connector.model.Result;
+import io.thinkit.edc.client.connector.resource.identity.IdentityResource;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.UnaryOperator;
 
-public class Participants {
+public class Participants extends IdentityResource {
+
     private final String url;
-    private final EdcApiHttpClient edcApiHttpClient;
 
-    private final ObjectMapper objectMapper;
-
-    public Participants(
-            String url,
-            HttpClient httpClient,
-            UnaryOperator<HttpRequest.Builder> interceptor,
-            ObjectMapper objectMapper) {
-        edcApiHttpClient = new EdcApiHttpClient(httpClient, interceptor);
-        this.objectMapper = objectMapper;
-        this.url = "%s/v1alpha/participants".formatted(url);
+    public Participants(EdcClientContext context) {
+        super(context);
+        url = "%s/v1alpha/participants".formatted(identityUrl);
     }
 
     public Result<List<ParticipantContext>> getAll(int offset, int limit) {
         var requestBuilder = getAllRequestBuilder(offset, limit);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(this::getParticipants);
+        return context.httpClient().send(requestBuilder).map(this::getParticipants);
     }
 
     public CompletableFuture<Result<List<ParticipantContext>>> getAllAsync(int offset, int limit) {
         var requestBuilder = getAllRequestBuilder(offset, limit);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(this::getParticipants));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(this::getParticipants));
     }
 
     public Result<String> create(ParticipantManifest input) {
         var requestBuilder = createRequestBuilder(input);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(result -> input.participantId());
+        return context.httpClient().send(requestBuilder).map(result -> input.participantId());
     }
 
     public CompletableFuture<Result<String>> createAsync(ParticipantManifest input) {
         var requestBuilder = createRequestBuilder(input);
 
-        return this.edcApiHttpClient
+        return context.httpClient()
                 .sendAsync(requestBuilder)
                 .thenApply(result -> result.map(content -> input.participantId()));
     }
@@ -58,54 +52,50 @@ public class Participants {
     public Result<ParticipantContext> get(String participantId) {
         var requestBuilder = getRequestBuilder(participantId);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(this::getParticipant);
+        return context.httpClient().send(requestBuilder).map(this::getParticipant);
     }
 
     public CompletableFuture<Result<ParticipantContext>> getAsync(String participantId) {
         var requestBuilder = getRequestBuilder(participantId);
 
-        return this.edcApiHttpClient.sendAsync(requestBuilder).thenApply(result -> result.map(this::getParticipant));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(this::getParticipant));
     }
 
     public Result<String> delete(String participantId) {
         var requestBuilder = deleteRequestBuilder(participantId);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(result -> participantId);
+        return context.httpClient().send(requestBuilder).map(result -> participantId);
     }
 
     public CompletableFuture<Result<String>> deleteAsync(String participantId) {
         var requestBuilder = deleteRequestBuilder(participantId);
 
-        return this.edcApiHttpClient
-                .sendAsync(requestBuilder)
-                .thenApply(result -> result.map(content -> participantId));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(content -> participantId));
     }
 
     public Result<String> update(List<String> input, String participantId) {
         var requestBuilder = updateRequestBuilder(input, participantId);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(result -> participantId);
+        return context.httpClient().send(requestBuilder).map(result -> participantId);
     }
 
     public CompletableFuture<Result<String>> updateAsync(List<String> input, String participantId) {
         var requestBuilder = updateRequestBuilder(input, participantId);
 
-        return this.edcApiHttpClient
-                .sendAsync(requestBuilder)
-                .thenApply(result -> result.map(content -> participantId));
+        return context.httpClient().sendAsync(requestBuilder).thenApply(result -> result.map(content -> participantId));
     }
 
     public Result<String> activate(ParticipantManifest input, String participantId, Boolean isActive) {
         var requestBuilder = activateRequestBuilder(input, participantId, isActive);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(result -> input.participantId());
+        return context.httpClient().send(requestBuilder).map(result -> input.participantId());
     }
 
     public CompletableFuture<Result<String>> activateAsync(
             ParticipantManifest input, String participantId, Boolean isActive) {
         var requestBuilder = activateRequestBuilder(input, participantId, isActive);
 
-        return this.edcApiHttpClient
+        return context.httpClient()
                 .sendAsync(requestBuilder)
                 .thenApply(result -> result.map(content -> input.participantId()));
     }
@@ -113,13 +103,13 @@ public class Participants {
     public Result<String> generateToken(ParticipantManifest input, String participantId) {
         var requestBuilder = generateTokenRequestBuilder(input, participantId);
 
-        return this.edcApiHttpClient.send(requestBuilder).map(result -> input.participantId());
+        return context.httpClient().send(requestBuilder).map(result -> input.participantId());
     }
 
     public CompletableFuture<Result<String>> generateTokenAsync(ParticipantManifest input, String participantId) {
         var requestBuilder = generateTokenRequestBuilder(input, participantId);
 
-        return this.edcApiHttpClient
+        return context.httpClient()
                 .sendAsync(requestBuilder)
                 .thenApply(result -> result.map(content -> input.participantId()));
     }
@@ -137,9 +127,9 @@ public class Participants {
     }
 
     private HttpRequest.Builder createRequestBuilder(ParticipantManifest input) {
-        String requestBody = null;
+        String requestBody;
         try {
-            requestBody = objectMapper.writeValueAsString(input);
+            requestBody = context.objectMapper().writeValueAsString(input);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
@@ -150,9 +140,9 @@ public class Participants {
     }
 
     private HttpRequest.Builder updateRequestBuilder(List<String> input, String participantId) {
-        String requestBody = null;
+        String requestBody;
         try {
-            requestBody = objectMapper.writeValueAsString(input);
+            requestBody = context.objectMapper().writeValueAsString(input);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
@@ -170,9 +160,9 @@ public class Participants {
 
     private HttpRequest.Builder activateRequestBuilder(
             ParticipantManifest input, String participantId, Boolean isActive) {
-        String requestBody = null;
+        String requestBody;
         try {
-            requestBody = objectMapper.writeValueAsString(input);
+            requestBody = context.objectMapper().writeValueAsString(input);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
@@ -183,9 +173,9 @@ public class Participants {
     }
 
     private HttpRequest.Builder generateTokenRequestBuilder(ParticipantManifest input, String participantId) {
-        String requestBody = null;
+        String requestBody;
         try {
-            requestBody = objectMapper.writeValueAsString(input);
+            requestBody = context.objectMapper().writeValueAsString(input);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
@@ -197,7 +187,7 @@ public class Participants {
 
     private ParticipantContext getParticipant(InputStream body) {
         try {
-            return objectMapper.readValue(body, ParticipantContext.class);
+            return context.objectMapper().readValue(body, ParticipantContext.class);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -205,7 +195,7 @@ public class Participants {
 
     private List<ParticipantContext> getParticipants(InputStream body) {
         try {
-            return objectMapper.readValue(body, new TypeReference<List<ParticipantContext>>() {});
+            return context.objectMapper().readValue(body, new TypeReference<List<ParticipantContext>>() {});
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/test/java/io/thinkit/edc/client/connector/ApiContainer.java
+++ b/src/test/java/io/thinkit/edc/client/connector/ApiContainer.java
@@ -7,7 +7,7 @@ import org.testcontainers.containers.GenericContainer;
 public class ApiContainer extends GenericContainer<ApiContainer> {
 
     public ApiContainer(String file) {
-        super("stoplight/prism:5.4.0");
+        super("stoplight/prism:5.12.1");
         this.withClasspathResourceMapping(file, file, READ_WRITE);
         this.withCommand("mock -h 0.0.0.0 " + file);
         this.withExposedPorts(4010);

--- a/src/test/java/io/thinkit/edc/client/connector/services/CatalogCacheTest.java
+++ b/src/test/java/io/thinkit/edc/client/connector/services/CatalogCacheTest.java
@@ -1,20 +1,21 @@
 package io.thinkit.edc.client.connector.services;
 
-import static io.thinkit.edc.client.connector.utils.Constants.ODRL_NAMESPACE;
-import static java.util.Collections.emptyList;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.thinkit.edc.client.connector.CatalogApiTestBase;
 import io.thinkit.edc.client.connector.EdcConnectorClient;
 import io.thinkit.edc.client.connector.model.Catalog;
 import io.thinkit.edc.client.connector.model.QuerySpec;
 import io.thinkit.edc.client.connector.model.Result;
-import java.net.http.HttpClient;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+
+import java.net.http.HttpClient;
+import java.util.List;
+
+import static io.thinkit.edc.client.connector.utils.Constants.ODRL_NAMESPACE;
+import static java.util.Collections.emptyList;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class CatalogCacheTest extends CatalogApiTestBase {
 
@@ -23,7 +24,7 @@ class CatalogCacheTest extends CatalogApiTestBase {
 
     @BeforeEach
     void setUp() {
-        var client = new EdcConnectorClient.Builder()
+        var client = EdcConnectorClient.newBuilder()
                 .httpClient(http)
                 .catalogCacheUrl(prism.getUrl())
                 .build();


### PR DESCRIPTION
### What
Makes all the remaining resource to pass through the "extensibility" pattern by extending the `EdcResource` class

### Notes
Bumped prism to 5.12.1
Add a config on ObjectMapper to ignore unknown props, this will help a lot to avoid unexpected errors on new properties added on the api

Closes #174