### PR TITLE
refctor: remove duplication and create a common mapper

### DIFF
--- a/src/main/java/io/thinkit/edc/client/connector/model/Result.java
+++ b/src/main/java/io/thinkit/edc/client/connector/model/Result.java
@@ -47,4 +47,8 @@ public class Result<T> {
             return new Result<>(null, this.errors);
         }
     }
+
+    public <R> Result<R> flatMap(Function<Result<T>, Result<R>> mappingFunction) {
+        return mappingFunction.apply(this);
+    }
 }

--- a/src/main/java/io/thinkit/edc/client/connector/resource/management/ManagementResource.java
+++ b/src/main/java/io/thinkit/edc/client/connector/resource/management/ManagementResource.java
@@ -48,7 +48,7 @@ public class ManagementResource extends EdcResource {
         }
     }
 
-    protected <T> Function<Result<InputStream>, Result<T>> responseMapper(
+    protected <T> Function<Result<InputStream>, Result<T>> responseDeserializer(
             Function<JsonArray, T> v3Mapper, Function<InputStream, T> v4Mapper) {
         return managementVersion.equals(V3)
                 ? result -> result.map(JsonLdUtil::expand).map(v3Mapper)

--- a/src/main/java/io/thinkit/edc/client/connector/services/management/Assets.java
+++ b/src/main/java/io/thinkit/edc/client/connector/services/management/Assets.java
@@ -31,16 +31,16 @@ public class Assets extends ManagementResource {
 
     public Result<Asset> get(String id) {
         var requestBuilder = getRequestBuilder(id);
-        var function = responseMapper(this::getAsset, deserializeAsset());
+        var deserialize = responseDeserializer(this::getAsset, deserializeAsset());
 
-        return function.apply(context.httpClient().send(requestBuilder));
+        return context.httpClient().send(requestBuilder).flatMap(deserialize);
     }
 
     public CompletableFuture<Result<Asset>> getAsync(String id) {
         var requestBuilder = getRequestBuilder(id);
-        var function = responseMapper(this::getAsset, deserializeAsset());
+        var deserialize = responseDeserializer(this::getAsset, deserializeAsset());
 
-        return context.httpClient().sendAsync(requestBuilder).thenApply(function);
+        return context.httpClient().sendAsync(requestBuilder).thenApply(deserialize);
     }
 
     public Result<String> create(Asset input) {
@@ -87,16 +87,16 @@ public class Assets extends ManagementResource {
     public Result<List<Asset>> request(QuerySpec input) {
 
         var requestBuilder = getAssetsRequestBuilder(input);
-        var function = responseMapper(this::getAssets, deserializeAssets());
+        var deserialize = responseDeserializer(this::getAssets, deserializeAssets());
 
-        return function.apply(context.httpClient().send(requestBuilder));
+        return context.httpClient().send(requestBuilder).flatMap(deserialize);
     }
 
     public CompletableFuture<Result<List<Asset>>> requestAsync(QuerySpec input) {
         var requestBuilder = getAssetsRequestBuilder(input);
-        var function = responseMapper(this::getAssets, deserializeAssets());
+        var deserialize = responseDeserializer(this::getAssets, deserializeAssets());
 
-        return context.httpClient().sendAsync(requestBuilder).thenApply(function);
+        return context.httpClient().sendAsync(requestBuilder).thenApply(deserialize);
     }
 
     private Function<InputStream, List<Asset>> deserializeAssets() {

--- a/src/main/java/io/thinkit/edc/client/connector/services/management/ContractDefinitions.java
+++ b/src/main/java/io/thinkit/edc/client/connector/services/management/ContractDefinitions.java
@@ -31,15 +31,15 @@ public class ContractDefinitions extends ManagementResource {
 
     public Result<ContractDefinition> get(String id) {
         var requestBuilder = getRequestBuilder(id);
-        var function = responseMapper(this::getContractDefinition, deserializeContractDefinition());
-        return function.apply(context.httpClient().send(requestBuilder));
+        var deserialize = responseDeserializer(this::getContractDefinition, deserializeContractDefinition());
+        return context.httpClient().send(requestBuilder).flatMap(deserialize);
     }
 
     public CompletableFuture<Result<ContractDefinition>> getAsync(String id) {
         var requestBuilder = getRequestBuilder(id);
-        var function = responseMapper(this::getContractDefinition, deserializeContractDefinition());
+        var deserialize = responseDeserializer(this::getContractDefinition, deserializeContractDefinition());
 
-        return context.httpClient().sendAsync(requestBuilder).thenApply(function);
+        return context.httpClient().sendAsync(requestBuilder).thenApply(deserialize);
     }
 
     public Result<String> create(ContractDefinition input) {
@@ -71,17 +71,17 @@ public class ContractDefinitions extends ManagementResource {
     public Result<List<ContractDefinition>> request(QuerySpec input) {
 
         var requestBuilder = getContractDefinitionsRequestBuilder(input);
-        var function = responseMapper(this::getContractDefinitions, deserializeContractDefinitions());
+        var deserialize = responseDeserializer(this::getContractDefinitions, deserializeContractDefinitions());
 
-        return function.apply(context.httpClient().send(requestBuilder));
+        return context.httpClient().send(requestBuilder).flatMap(deserialize);
     }
 
     public CompletableFuture<Result<List<ContractDefinition>>> requestAsync(QuerySpec input) {
 
         var requestBuilder = getContractDefinitionsRequestBuilder(input);
-        var function = responseMapper(this::getContractDefinitions, deserializeContractDefinitions());
+        var deserialize = responseDeserializer(this::getContractDefinitions, deserializeContractDefinitions());
 
-        return context.httpClient().sendAsync(requestBuilder).thenApply(function);
+        return context.httpClient().sendAsync(requestBuilder).thenApply(deserialize);
     }
 
     public Result<String> update(ContractDefinition input) {

--- a/src/main/java/io/thinkit/edc/client/connector/services/management/Dataplanes.java
+++ b/src/main/java/io/thinkit/edc/client/connector/services/management/Dataplanes.java
@@ -26,15 +26,15 @@ public class Dataplanes extends ManagementResource {
 
     public Result<List<DataPlaneInstance>> get() {
         var requestBuilder = getRequestBuilder();
-        var function = responseMapper(this::getDataPlaneInstances, deserializeDataPlaneInstances());
-        return function.apply(context.httpClient().send(requestBuilder));
+        var deserialize = responseDeserializer(this::getDataPlaneInstances, deserializeDataPlaneInstances());
+        return context.httpClient().send(requestBuilder).flatMap(deserialize);
     }
 
     public CompletableFuture<Result<List<DataPlaneInstance>>> getAsync() {
         var requestBuilder = getRequestBuilder();
-        var function = responseMapper(this::getDataPlaneInstances, deserializeDataPlaneInstances());
+        var deserialize = responseDeserializer(this::getDataPlaneInstances, deserializeDataPlaneInstances());
 
-        return context.httpClient().sendAsync(requestBuilder).thenApply(function);
+        return context.httpClient().sendAsync(requestBuilder).thenApply(deserialize);
     }
 
     private HttpRequest.Builder getRequestBuilder() {

--- a/src/main/java/io/thinkit/edc/client/connector/services/management/Secrets.java
+++ b/src/main/java/io/thinkit/edc/client/connector/services/management/Secrets.java
@@ -29,16 +29,16 @@ public class Secrets extends ManagementResource {
 
     public Result<Secret> get(String id) {
         var requestBuilder = getRequestBuilder(id);
-        var function = responseMapper(this::getSecret, deserializeSecret());
+        var deserialize = responseDeserializer(this::getSecret, deserializeSecret());
 
-        return function.apply(context.httpClient().send(requestBuilder));
+        return context.httpClient().send(requestBuilder).flatMap(deserialize);
     }
 
     public CompletableFuture<Result<Secret>> getAsync(String id) {
         var requestBuilder = getRequestBuilder(id);
-        var function = responseMapper(this::getSecret, deserializeSecret());
+        var deserialize = responseDeserializer(this::getSecret, deserializeSecret());
 
-        return context.httpClient().sendAsync(requestBuilder).thenApply(function);
+        return context.httpClient().sendAsync(requestBuilder).thenApply(deserialize);
     }
 
     public Result<String> create(Secret input) {


### PR DESCRIPTION
### Description
In this PR, we will add a shared mapper to consolidate duplicated mapping logic across services.